### PR TITLE
Add package_deps.yml

### DIFF
--- a/package_deps.yml
+++ b/package_deps.yml
@@ -1,0 +1,27 @@
+# This configures the version of the grpc and other packages 
+# (e.g, the google auth library) to be used as dependencies 
+# of the googleapis packages generated from the protos in
+# this repo.
+#
+# Rationale:
+# - at a given point, in any language, googleapis packages generated should depend
+#   on consistent versions of their dependencies
+# - the tool that creates the packages should pick up the version from a configuration file
+# - it's nice to have the information all in one place to make it convenient to update
+#   e.g, when new apis are added or when there is a gRPC release.
+
+csharp:
+  grpc: 0.5.1
+
+python: 
+  grpcio: 0.9.0a0
+  oauth2client 1.4.11
+
+node:
+  grpc: 0.9.0
+  google-auth-library: 0.9.6
+
+ruby:
+  grpc: 0.9.3
+  googleauth: 0.4.1
+  


### PR DESCRIPTION
Configures the semantic versions of the dependencies to use when generating 
googleapis packages from the api protos
