### PR TITLE
Remove API name prefix from artman config

### DIFF
--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -1,4 +1,4 @@
-logging_common:
+common:
   api_name: logging-v2
   import_proto_path:
     - ${THISDIR}/../..
@@ -12,20 +12,20 @@ logging_common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${THISDIR}/../../google/logging/v2/logging_gapic.yaml
-logging_type:
+type:
   api_name: logging-type
   import_proto_path:
     - ${THISDIR}/../..
   src_proto_path:
     - ${THISDIR}/../../google/logging/type
   output_dir: ${REPOROOT}/artman/output
-logging_java:
+java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-logging
-logging_python:
+python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-logging
-logging_go:
+go:
   final_repo_dir: ${REPOROOT}/gapi-logging-go
-logging_csharp:
+csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-logging
-logging_ruby:
+ruby:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-logging

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -1,4 +1,4 @@
-pubsub_common:
+common:
   api_name: pubsub-v1
   import_proto_path:
     - ${THISDIR}/../..
@@ -12,15 +12,15 @@ pubsub_common:
   auto_resolve: true
   ignore_base: false
   output_dir: ${REPOROOT}/artman/output
-pubsub_java:
+java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-pubsub
-pubsub_python:
+python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-pubsub
-pubsub_go:
+go:
   final_repo_dir: ${REPOROOT}/gapi-pubsub-go
-pubsub_csharp:
+csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-pubsub
-pubsub_php:
+php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-pubsub
-pubsub_ruby:
+ruby:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-pubsub


### PR DESCRIPTION
These values are scoped to the file itself, therefore these
API name prefix is simply redundant. It's a bit irritating
when typing artman commandline into the terminal.