### PR TITLE
Add required_fields to logging_gapic config

### DIFF
--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -41,6 +41,8 @@ interfaces:
       groups:
       - parameters:
         - project_name
+    required_fields:
+      - project_name
     page_streaming:
       request:
         token_field: page_token
@@ -58,6 +60,8 @@ interfaces:
       groups:
       - parameters:
         - sink_name
+    required_fields:
+      - sink_name
     retry_codes_name: idempotent
     retry_params_name: default
     request_object_method: false
@@ -70,6 +74,9 @@ interfaces:
       - parameters:
         - project_name
         - sink
+    required_fields:
+      - project_name
+      - sink
     retry_codes_name: non_idempotent
     retry_params_name: default
     request_object_method: true
@@ -82,6 +89,9 @@ interfaces:
       - parameters:
         - sink_name
         - sink
+    required_fields:
+      - sink_name
+      - sink
     retry_codes_name: non_idempotent
     retry_params_name: default
     request_object_method: true
@@ -127,6 +137,8 @@ interfaces:
       groups:
       - parameters:
         - project_name
+    required_fields:
+      - project_name
     page_streaming:
       request:
         token_field: page_token
@@ -144,6 +156,8 @@ interfaces:
       groups:
       - parameters:
         - metric_name
+    required_fields:
+      - metric_name
     retry_codes_name: idempotent
     retry_params_name: default
     request_object_method: false
@@ -156,6 +170,9 @@ interfaces:
       - parameters:
         - project_name
         - metric
+    required_fields:
+      - project_name
+      - metric
     retry_codes_name: non_idempotent
     retry_params_name: default
     request_object_method: true
@@ -168,6 +185,9 @@ interfaces:
       - parameters:
         - metric_name
         - metric
+    required_fields:
+      - metric_name
+      - metric
     retry_codes_name: non_idempotent
     retry_params_name: default
     request_object_method: true
@@ -179,6 +199,8 @@ interfaces:
       groups:
       - parameters:
         - metric_name
+    required_fields:
+      - metric_name
     retry_codes_name: idempotent
     retry_params_name: default
     request_object_method: false
@@ -221,6 +243,8 @@ interfaces:
       groups:
       - parameters:
         - log_name
+    required_fields:
+      - log_name
     retry_codes_name: idempotent
     retry_params_name: default
     request_object_method: false
@@ -235,6 +259,8 @@ interfaces:
         - resource
         - labels
         - entries
+    required_fields:
+      - entries
     retry_codes_name: non_idempotent
     retry_params_name: default
     request_object_method: true
@@ -248,6 +274,8 @@ interfaces:
         - project_ids
         - filter
         - order_by
+    required_fields:
+      - project_ids
     page_streaming:
       request:
         token_field: page_token

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -103,6 +103,8 @@ interfaces:
       groups:
       - parameters:
         - sink_name
+    required_fields:
+      - sink_name
     retry_codes_name: idempotent
     retry_params_name: default
     request_object_method: false


### PR DESCRIPTION
Noticed we do not have required_fields in logging API...