### PR TITLE
Python release fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ OWNERS
 README.google
 google/internal
 google/protobuf
+.project

--- a/google/logging/v2/log_entry.proto
+++ b/google/logging/v2/log_entry.proto
@@ -104,7 +104,7 @@ message LogEntryOperation {
 
   // Required. An arbitrary producer identifier. The combination of
   // `id` and `producer` must be globally unique.  Examples for `producer`:
-  // `"MyDivision.MyBigCompany.com"`, "github.com/MyProject/MyApplication"`.
+  // `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
   //
   string producer = 2;
 

--- a/google/logging/v2/logging_config.proto
+++ b/google/logging/v2/logging_config.proto
@@ -25,6 +25,8 @@ option java_outer_classname = "LoggingConfig";
 option java_package = "com.google.logging.v2";
 
 
+// Service for configuring sinks used to export log entries outside Stackdriver
+// Logging.
 service ConfigServiceV2 {
   // Lists sinks.
   rpc ListSinks(ListSinksRequest) returns (ListSinksResponse) {

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -4,7 +4,7 @@ language_settings:
   java:
     package_name: com.google.cloud.logging.spi.v2
   python:
-    package_name: gcloud.logging
+    package_name: google.logging.v2
   go:
     package_name: google.golang.org/cloud/logging
   csharp:

--- a/google/logging/v2/logging_metrics.proto
+++ b/google/logging/v2/logging_metrics.proto
@@ -23,6 +23,7 @@ option java_multiple_files = true;
 option java_package = "com.google.logging.v2";
 
 
+// Service for configuring logs-based metrics.
 service MetricsServiceV2 {
   // Lists logs-based metrics.
   rpc ListLogMetrics(ListLogMetricsRequest) returns (ListLogMetricsResponse) {

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -4,7 +4,7 @@ language_settings:
   java:
     package_name: com.google.cloud.pubsub.spi.v1
   python:
-    package_name: gcloud.pubsub
+    package_name: google.pubsub.v1
   go:
     package_name: google.golang.org/cloud/pubsub
   csharp:


### PR DESCRIPTION
This includes:

* renaming the Python package names for package delivery, which is what we're doing right now
* adding service-level comments, since Sphinx depends on class-level docstrings in the generated code (which come from service-level proto comments)
* fixing a typo in the proto comments (also fixed upstream in a CL)