### PR TITLE
Packman fix

### DIFF
--- a/gapic/api/artman_cloudtrace.yaml
+++ b/gapic/api/artman_cloudtrace.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: devtools-cloudtrace-v1
+  api_name: google-devtools-cloudtrace-v1
   import_proto_path:
     - ${THISDIR}/../..
   src_proto_path:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: logging-v2
+  api_name: google-logging-v2
   import_proto_path:
     - ${THISDIR}/../..
   src_proto_path:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: monitoring-v3
+  api_name: google-monitoring-v3
   import_proto_path:
     - ${THISDIR}/../..
   src_proto_path:

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: pubsub-v1
+  api_name: google-pubsub-v1
   import_proto_path:
     - ${THISDIR}/../..
   src_proto_path:


### PR DESCRIPTION
This enables artman to run gRPC packman without the isGoogleApi flag.