### PR TITLE
Add go_package attribute to logging protos

### DIFF
--- a/google/api/monitored_resource.proto
+++ b/google/api/monitored_resource.proto
@@ -22,6 +22,7 @@ option java_multiple_files = true;
 option java_outer_classname = "MonitoredResourceProto";
 option java_package = "com.google.api";
 
+option go_package = "google.golang.org/genproto/googleapis/api/monitoredres";
 
 // An object that describes the schema of a [MonitoredResource][google.api.MonitoredResource] object using a
 // type name and a set of labels.  For example, the monitored resource

--- a/google/logging/v2/log_entry.proto
+++ b/google/logging/v2/log_entry.proto
@@ -29,6 +29,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LogEntryProto";
 option java_package = "com.google.logging.v2";
 
+option go_package = "google.golang.org/genproto/googleapis/logging/v2";
 
 // An individual entry in a log.
 message LogEntry {

--- a/google/logging/v2/logging.proto
+++ b/google/logging/v2/logging.proto
@@ -29,6 +29,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingProto";
 option java_package = "com.google.logging.v2";
 
+option go_package = "google.golang.org/genproto/googleapis/logging/v2";
 
 // Service for ingesting and querying logs.
 service LoggingServiceV2 {

--- a/google/logging/v2/logging_config.proto
+++ b/google/logging/v2/logging_config.proto
@@ -24,6 +24,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingConfig";
 option java_package = "com.google.logging.v2";
 
+option go_package = "google.golang.org/genproto/googleapis/logging/v2";
 
 // Service for configuring sinks used to export log entries outside Stackdriver
 // Logging.

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -6,7 +6,7 @@ language_settings:
   python:
     package_name: google.logging.v2
   go:
-    package_name: google.golang.org/cloud/logging
+    package_name: cloud.google.com/go/logging/apiv2
   csharp:
     package_name: Google.Logging.V2
   ruby:

--- a/google/logging/v2/logging_metrics.proto
+++ b/google/logging/v2/logging_metrics.proto
@@ -22,6 +22,7 @@ import "google/protobuf/empty.proto";
 option java_multiple_files = true;
 option java_package = "com.google.logging.v2";
 
+option go_package = "google.golang.org/genproto/googleapis/logging/v2";
 
 // Service for configuring logs-based metrics.
 service MetricsServiceV2 {


### PR DESCRIPTION
The attribute is essentially required so that the generated client
can find what it needs

Fixes googleapis/toolkit#329.