### PR TITLE
Introduce cloud-speech API config yaml.

### DIFF
--- a/gapic/api/artman_speech.yaml
+++ b/gapic/api/artman_speech.yaml
@@ -1,0 +1,28 @@
+common:
+  api_name: google-cloud-speech-v1
+  import_proto_path:
+    - ${THISDIR}/../..
+  src_proto_path:
+    - ${THISDIR}/../../google/cloud/speech/v1
+  service_yaml:
+    - ${THISDIR}/../../google/cloud/speech/cloud_speech.yaml
+  auto_merge: true
+  auto_resolve: true
+  ignore_base: false
+  output_dir: ${REPOROOT}/artman/output
+  gapic_api_yaml:
+    - ${THISDIR}/../../google/cloud/speech/v1/cloud_speech_gapic.yaml
+java:
+  final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-cloud-speech
+python:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-speech
+go:
+  final_repo_dir: ${REPOROOT}/gapi-cloud-speech-go
+csharp:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
+ruby:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-cloud-speech
+php:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+nodejs:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-cloud-speech

--- a/gapic/api/artman_speech.yaml
+++ b/gapic/api/artman_speech.yaml
@@ -21,8 +21,8 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-cloud-speech
+  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-speech
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
 nodejs:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-cloud-speech
+  final_repo_dir: ${REPOROOT}/gcloud-node/packages/speech

--- a/google/cloud/speech/cloud_speech.yaml
+++ b/google/cloud/speech/cloud_speech.yaml
@@ -1,0 +1,29 @@
+# Google Cloud Speech API service configuration
+
+type: google.api.Service
+config_version: 1
+name: speech.googleapis.com
+
+title: Google Cloud Speech API
+
+documentation:
+  summary:
+    Google Cloud Speech API.
+
+apis:
+- name: google.cloud.speech.v1.Speech
+
+# Pass origin and project RpcServerExtensions to the backend.
+context:
+  rules:
+  - selector: '*'
+    requested:
+    - google.rpc.context.OriginContext
+    - google.rpc.context.ProjectContext
+
+# Auth section
+authentication:
+  rules:
+    - selector: '*'
+      oauth:
+        canonical_scopes: https://www.googleapis.com/auth/cloud-platform

--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -2,7 +2,7 @@ type: com.google.api.codegen.ConfigProto
 generate_samples: true
 language_settings:
   java:
-    package_name: com.google.cloud.speech.v1
+    package_name: com.google.cloud.speech.spi.v1
   python:
     package_name: google.cloud.speech.v1
   go:

--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -13,6 +13,8 @@ language_settings:
     package_name: Google::Cloud::Speech::V1
   php:
     package_name: Google\Cloud\Speech\V1
+  nodejs:
+    package_name: "@google-cloud/speech"
 interfaces:
 - name: google.cloud.speech.v1.Speech
   collections: []
@@ -36,7 +38,7 @@ interfaces:
   - name: Recognize
     retry_codes_name: non_idempotent
     retry_params_name: default
-    timeout_millis: 30000
+    timeout_millis: 60000
   - name: NonStreamingRecognize
     flattening:
       groups:
@@ -49,4 +51,4 @@ interfaces:
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
-    timeout_millis: 30000
+    timeout_millis: 60000

--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -1,0 +1,52 @@
+type: com.google.api.codegen.ConfigProto
+generate_samples: true
+language_settings:
+  java:
+    package_name: com.google.cloud.speech.v1
+  python:
+    package_name: google.cloud.speech.v1
+  go:
+    package_name: google.golang.org/google/cloud/speech/v1
+  csharp:
+    package_name: Google.Cloud.Speech.V1
+  ruby:
+    package_name: Google::Cloud::Speech::V1
+  php:
+    package_name: Google\Cloud\Speech\V1
+interfaces:
+- name: google.cloud.speech.v1.Speech
+  collections: []
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 60000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 60000
+    total_timeout_millis: 600000
+  methods:
+  - name: Recognize
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 30000
+  - name: NonStreamingRecognize
+    flattening:
+      groups:
+      - parameters:
+        - initial_request
+        - audio_request
+    required_fields:
+    - initial_request
+    - audio_request
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 30000


### PR DESCRIPTION
- changed RecognizeNonStreaming() to idempotent

"Recognize" method is a bidi-streaming method, which is not
supported by Gapic codegen, but yet it should exist when
we want to support it for some language.

Anyways streaming methods will be ignored as
https://github.com/googleapis/toolkit/pull/328