### PR TITLE
Modify final_repo_dir for Ruby and NodeJS

### DIFF
--- a/gapic/api/artman_language.yaml
+++ b/gapic/api/artman_language.yaml
@@ -21,8 +21,8 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-cloud-language
+  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-language
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
 nodejs:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-cloud-language
+  final_repo_dir: ${REPOROOT}/gcloud-node/packages/language

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -28,8 +28,8 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-logging
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-logging
+  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-logging
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-logging
 nodejs:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-logging
+  final_repo_dir: ${REPOROOT}/gcloud-node/packages/logging

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -23,6 +23,6 @@ csharp:
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-pubsub
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-pubsub
+  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-pubsub
 nodejs:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-pubsub
+  final_repo_dir: ${REPOROOT}/gcloud-node/packages/pubsub

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -13,6 +13,8 @@ language_settings:
     package_name: Google::Cloud::Language::V1beta1
   php:
     package_name: Google\Cloud\Language\V1Beta1
+  nodejs:
+    package_name: "@google-cloud/language"
 interfaces:
 - name: google.cloud.language.v1beta1.LanguageService
   collections: []

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -13,6 +13,8 @@ language_settings:
     package_name: Google::Logging::V2
   php:
     package_name: Google\Cloud\Logging\V2
+  nodejs:
+    package_name: "@google-cloud/logging"
 interfaces:
 - name: google.logging.v2.ConfigServiceV2
   collections:

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -13,6 +13,8 @@ language_settings:
     package_name: Google::Pubsub::V1
   php:
     package_name: Google\Cloud\PubSub\V1
+  nodejs:
+    package_name: "@google-cloud/pubsub"
 interfaces:
 - name: google.pubsub.v1.Subscriber
   collections:


### PR DESCRIPTION
They are going to be a part of gcloud, therefore those paths.

It's unclear what is the package names for other APIs, so their
artman configs are unchanged.