### PR TITLE
removing type section from artman_logging

### DIFF
--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -12,13 +12,6 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${THISDIR}/../../google/logging/v2/logging_gapic.yaml
-type:
-  api_name: logging-type
-  import_proto_path:
-    - ${THISDIR}/../..
-  src_proto_path:
-    - ${THISDIR}/../../google/logging/type
-  output_dir: ${REPOROOT}/artman/output
 java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-logging
 python:


### PR DESCRIPTION
The protos in logging/type are now included in artman_core.