### PR TITLE
Update artmam/gapic yamls to use ${ROOTREPO} and ${TOOLKIT_HOME}

### DIFF
--- a/gapic/api/artman_cloudtrace.yaml
+++ b/gapic/api/artman_cloudtrace.yaml
@@ -1,13 +1,13 @@
 common:
   api_name: google-devtools-cloudtrace-v1
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/devtools/cloudtrace/v1
+    - ${REPOROOT}/googleapis/google/devtools/cloudtrace/v1
   service_yaml:
-    - ${THISDIR}/../../google/devtools/cloudtrace/trace.yaml
+    - ${REPOROOT}/googleapis/google/devtools/cloudtrace/trace.yaml
   gapic_api_yaml:
-    - ${THISDIR}/../../google/devtools/cloudtrace/v1/trace_gapic.yaml
+    - ${REPOROOT}/googleapis/google/devtools/cloudtrace/v1/trace_gapic.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -1,13 +1,13 @@
 common:
   api_name: google-devtools-clouderrorreporting-v1beta1
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/devtools/clouderrorreporting/v1beta1
+    - ${REPOROOT}/googleapis/google/devtools/clouderrorreporting/v1beta1
   service_yaml:
-    - ${THISDIR}/../../google/devtools/clouderrorreporting/errorreporting.yaml
+    - ${REPOROOT}/googleapis/google/devtools/clouderrorreporting/errorreporting.yaml
   gapic_api_yaml:
-    - ${THISDIR}/../../google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+    - ${REPOROOT}/googleapis/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false

--- a/gapic/api/artman_language.yaml
+++ b/gapic/api/artman_language.yaml
@@ -1,17 +1,17 @@
 common:
   api_name: google-cloud-language-v1beta1
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/cloud/language/v1beta1
+    - ${REPOROOT}/googleapis/google/cloud/language/v1beta1
   service_yaml:
-    - ${THISDIR}/../../google/cloud/language/language.yaml
+    - ${REPOROOT}/googleapis/google/cloud/language/language.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
-    - ${THISDIR}/../../google/cloud/language/v1beta1/language_gapic.yaml
+    - ${REPOROOT}/googleapis/google/cloud/language/v1beta1/language_gapic.yaml
 java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-cloud-language
 python:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -1,17 +1,17 @@
 common:
   api_name: google-logging-v2
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/logging/v2
+    - ${REPOROOT}/googleapis/google/logging/v2
   service_yaml:
-    - ${THISDIR}/../../google/logging/logging.yaml
+    - ${REPOROOT}/googleapis/google/logging/logging.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
-    - ${THISDIR}/../../google/logging/v2/logging_gapic.yaml
+    - ${REPOROOT}/googleapis/google/logging/v2/logging_gapic.yaml
 java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-logging
 python:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -1,13 +1,13 @@
 common:
   api_name: google-monitoring-v3
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/monitoring/v3
+    - ${REPOROOT}/googleapis/google/monitoring/v3
   service_yaml:
-    - ${THISDIR}/../../google/monitoring/monitoring.yaml
+    - ${REPOROOT}/googleapis/google/monitoring/monitoring.yaml
   gapic_api_yaml:
-    - ${THISDIR}/../../google/monitoring/v3/monitoring_gapic.yaml
+    - ${REPOROOT}/googleapis/google/monitoring/v3/monitoring_gapic.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -1,13 +1,13 @@
 common:
   api_name: google-pubsub-v1
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/pubsub/v1
+    - ${REPOROOT}/googleapis/google/pubsub/v1
   service_yaml:
-    - ${THISDIR}/../../google/pubsub/pubsub.yaml
+    - ${REPOROOT}/googleapis/google/pubsub/pubsub.yaml
   gapic_api_yaml:
-    - ${THISDIR}/../../google/pubsub/v1/pubsub_gapic.yaml
+    - ${REPOROOT}/googleapis/google/pubsub/v1/pubsub_gapic.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false

--- a/gapic/api/artman_speech.yaml
+++ b/gapic/api/artman_speech.yaml
@@ -1,17 +1,17 @@
 common:
   api_name: google-cloud-speech-v1
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/cloud/speech/v1
+    - ${REPOROOT}/googleapis/google/cloud/speech/v1
   service_yaml:
-    - ${THISDIR}/../../google/cloud/speech/cloud_speech.yaml
+    - ${REPOROOT}/googleapis/google/cloud/speech/cloud_speech.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
-    - ${THISDIR}/../../google/cloud/speech/v1/cloud_speech_gapic.yaml
+    - ${REPOROOT}/googleapis/google/cloud/speech/v1/cloud_speech_gapic.yaml
 java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-cloud-speech
 python:

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -1,17 +1,17 @@
 common:
   api_name: google-cloud-vision-v1
   import_proto_path:
-    - ${THISDIR}/../..
+    - ${REPOROOT}/googleapis
   src_proto_path:
-    - ${THISDIR}/../../google/cloud/vision/v1
+    - ${REPOROOT}/googleapis/google/cloud/vision/v1
   service_yaml:
-    - ${THISDIR}/../../google/cloud/vision/vision.yaml
+    - ${REPOROOT}/googleapis/google/cloud/vision/vision.yaml
   auto_merge: true
   auto_resolve: true
   ignore_base: false
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
-    - ${THISDIR}/../../google/cloud/vision/v1/vision_gapic.yaml
+    - ${REPOROOT}/googleapis/google/cloud/vision/v1/vision_gapic.yaml
 java:
   final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-cloud-vision
 python:


### PR DESCRIPTION
Update artmam/gapic yamls to use ${ROOTREPO} and ${TOOLKIT_HOME} instead of ${THISDIR}.

This will make it possible for remote pipeline to create a isloated/temporary directory to host input/output/intermediate data/files. The downside is that it requires user to specify googleapis directory location relative to ${ROOTREPO}.