### PR TITLE
Add longrunning artman configuration

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -11,7 +11,7 @@ found. Currently, package delivery is only being done for Python.
 - [gRPC for common protos](https://pypi.python.org/pypi/googleapis-common-protos) ([source](https://github.com/googleapis/googleapis))
 - [Long-running
   operations](https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto)
-  - GAX: TBD
+  - [GAX](https://pypi.python.org/pypi/grpc-google-longrunning-v2)
   - gRPC: TBD
   - Documentation: TBD
 

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -11,8 +11,8 @@ found. Currently, package delivery is only being done for Python.
 - [gRPC for common protos](https://pypi.python.org/pypi/googleapis-common-protos) ([source](https://github.com/googleapis/googleapis))
 - [Long-running
   operations](https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto)
-  - [GAX](https://pypi.python.org/pypi/grpc-google-longrunning-v2)
-  - gRPC: TBD
+  - GAX: TBD
+  - [gRPC](https://pypi.python.org/pypi/grpc-google-longrunning-v2)
   - Documentation: TBD
 
 ### [Cloud Bigtable](https://cloud.google.com/bigtable/)

--- a/gapic/api/artman_longrunning.yaml
+++ b/gapic/api/artman_longrunning.yaml
@@ -1,0 +1,11 @@
+common:
+  api_name: google-longrunning-v2
+  import_proto_path:
+    - ${REPOROOT}/googleapis
+  src_proto_path:
+    - ${REPOROOT}/googleapis/google/longrunning
+  service_yaml:
+    - # No GAPIC configuration currently availabe
+  output_dir: ${REPOROOT}/artman/output
+  gapic_api_yaml:
+    - # No GAPIC configuration currently available


### PR DESCRIPTION
Currently this is just a minimal artman config for generating the
Python gRPC client library; it does not contain the information needed
to run GAPIC.