### PR TITLE
Add non-admin bigtable configs

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -1,0 +1,25 @@
+common:
+  api_name: google-bigtable-v2
+  import_proto_path:
+    - ${REPOROOT}/googleapis
+  src_proto_path:
+    - ${REPOROOT}/googleapis/google/bigtable/v2
+  service_yaml:
+    - ${REPOROOT}/googleapis/google/bigtable/bigtable.yaml
+  output_dir: ${REPOROOT}/artman/output
+  gapic_api_yaml:
+    - ${REPOROOT}/googleapis/google/bigtable/v2/bigtable_gapic.yaml
+java:
+  final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-bigtable
+python:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-bigtable
+go:
+  final_repo_dir: ${REPOROOT}/gapi-bigtable-go
+csharp:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-bigtable
+ruby:
+  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-bigtable
+php:
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-bigtable
+nodejs:
+  final_repo_dir: ${REPOROOT}/gcloud-node/packages/bigtable

--- a/google/bigtable/bigtable.yaml
+++ b/google/bigtable/bigtable.yaml
@@ -1,0 +1,34 @@
+# Google Bigtable API service configuration
+
+type: google.api.Service
+config_version: 0
+name: bigtable.googleapis.com
+
+title: Google Cloud Bigtable API
+
+documentation:
+  summary:
+    Google Cloud Bigtable - http://cloud.google.com/bigtable/
+
+apis:
+- name: google.bigtable.v2.Bigtable
+
+authentication:
+  rules:
+    # Unless explicitly weakened, all ops require write access
+    - selector: '*'
+      oauth:
+        canonical_scopes: https://www.googleapis.com/auth/bigtable.data,
+                          https://www.googleapis.com/auth/cloud-bigtable.data,
+                          https://www.googleapis.com/auth/cloud-platform
+
+    # Ops which only require read access
+    - selector: google.bigtable.v2.Bigtable.ReadRows,
+                google.bigtable.v2.Bigtable.SampleRowKeys
+      oauth:
+        canonical_scopes: https://www.googleapis.com/auth/bigtable.data,
+                          https://www.googleapis.com/auth/bigtable.data.readonly,
+                          https://www.googleapis.com/auth/cloud-bigtable.data,
+                          https://www.googleapis.com/auth/cloud-bigtable.data.readonly,
+                          https://www.googleapis.com/auth/cloud-platform,
+                          https://www.googleapis.com/auth/cloud-platform.read-only

--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -40,14 +40,8 @@ interfaces:
       groups:
       - parameters:
         - table_name
-        - rows
-        - filter
-        - rows_limit
     required_fields:
     - table_name
-    - rows
-    - filter
-    - rows_limit
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -100,12 +94,18 @@ interfaces:
       table_name: table
     timeout_millis: 60000
   - name: CheckAndMutateRow
+    flattening:
+      groups:
+      - parameters:
+          - table_name
+          - row_key
+          - true_mutations
+          - false_mutations
+    # Note that one of {true_mutations,false_mutations} must be specified, but
+    # since they are not both required, we leave them as optional params.
     required_fields:
     - table_name
     - row_key
-    - predicate_filter
-    - true_mutations
-    - false_mutations
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default

--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -1,0 +1,131 @@
+type: com.google.api.codegen.ConfigProto
+generate_samples: true
+language_settings:
+  java:
+    package_name: com.google.cloud.bigtable.spi.v2
+  python:
+    package_name: google.cloud.bigtable.v2
+  go:
+    package_name: cloud.google.com/go/bigtable/apiv2
+  csharp:
+    package_name: Google.Bigtable.V2
+  ruby:
+    package_name: Google::Bigtable::V2
+  php:
+    package_name: Google\Cloud\Bigtable\V2
+interfaces:
+- name: google.bigtable.v2.Bigtable
+  collections:
+  - name_pattern: projects/{project}/instances/{instance}/tables/{table}
+    entity_name: table
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  methods:
+  - name: ReadRows
+    flattening:
+      groups:
+      - parameters:
+        - table_name
+        - rows
+        - filter
+        - rows_limit
+    required_fields:
+    - table_name
+    - rows
+    - filter
+    - rows_limit
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      table_name: table
+    timeout_millis: 60000
+  - name: SampleRowKeys
+    flattening:
+      groups:
+      - parameters:
+        - table_name
+    required_fields:
+    - table_name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      table_name: table
+    timeout_millis: 60000
+  - name: MutateRow
+    flattening:
+      groups:
+      - parameters:
+        - table_name
+        - row_key
+        - mutations
+    required_fields:
+    - table_name
+    - row_key
+    - mutations
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      table_name: table
+    timeout_millis: 60000
+  - name: MutateRows
+    flattening:
+      groups:
+      - parameters:
+        - table_name
+        - entries
+    required_fields:
+    - table_name
+    - entries
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      table_name: table
+    timeout_millis: 60000
+  - name: CheckAndMutateRow
+    required_fields:
+    - table_name
+    - row_key
+    - predicate_filter
+    - true_mutations
+    - false_mutations
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      table_name: table
+    timeout_millis: 60000
+  - name: ReadModifyWriteRow
+    flattening:
+      groups:
+      - parameters:
+        - table_name
+        - row_key
+        - rules
+    required_fields:
+    - table_name
+    - row_key
+    - rules
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      table_name: table
+    timeout_millis: 60000


### PR DESCRIPTION
Includes service, artman, GAPIC configs with hand-edits to required fields in the GAPIC config.

Note that this does not address the Bigtable admin APIs.