### PR TITLE
Fix Ruby configurations.

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -20,7 +20,7 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-bigtable
 ruby:
-  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-bigtable
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-bigtable
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-bigtable
 nodejs:

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -22,6 +22,6 @@ csharp:
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-errorreporting
 ruby:
-  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-errorreporting
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-errorreporting
 nodejs:
   final_repo_dir: ${REPOROOT}/gcloud-node/packages/errorreporting

--- a/gapic/api/artman_language.yaml
+++ b/gapic/api/artman_language.yaml
@@ -20,7 +20,7 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
 ruby:
-  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-language
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-language
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
 nodejs:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -21,7 +21,7 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-logging
 ruby:
-  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-logging
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-logging
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-logging
 nodejs:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -15,3 +15,5 @@ java:
   final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-monitoring
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-monitoring
+ruby:
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-monitoring

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -26,6 +26,6 @@ csharp:
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-pubsub
 ruby:
-  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-pubsub
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-pubsub
 nodejs:
   final_repo_dir: ${REPOROOT}/gcloud-node/packages/pubsub

--- a/gapic/api/artman_speech.yaml
+++ b/gapic/api/artman_speech.yaml
@@ -20,7 +20,7 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
 ruby:
-  final_repo_dir: ${REPOROOT}/gcloud-ruby/google-cloud-speech
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-speech
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
 nodejs:

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -16,7 +16,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-trace
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-trace
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-trace
 nodejs:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-trace
 php:

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -20,7 +20,7 @@ go:
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-vision
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-cloud-vision
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-vision
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-vision
 nodejs:

--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -9,7 +9,7 @@ language_settings:
   csharp:
     package_name: Google.Bigtable.V2
   ruby:
-    package_name: Google::Bigtable::V2
+    package_name: Google::Cloud::Bigtable::V2
   php:
     package_name: Google\Cloud\Bigtable\V2
 interfaces:

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -9,7 +9,7 @@ language_settings:
   csharp:
     package_name: Google.Errorreporting.V1beta1
   ruby:
-    package_name: Google::Errorreporting::V1beta1
+    package_name: Google::Cloud::Errorreporting::V1beta1
   php:
     package_name: Google\Cloud\Errorreporting\V1beta1
   nodejs:

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -9,7 +9,7 @@ language_settings:
   csharp:
     package_name: Google.Logging.V2
   ruby:
-    package_name: Google::Logging::V2
+    package_name: Google::Cloud::Logging::V2
   php:
     package_name: Google\Cloud\Logging\V2
   nodejs:

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -9,7 +9,7 @@ language_settings:
   csharp:
     package_name: Google.Monitoring.V3
   ruby:
-    package_name: Google::Monitoring::V3
+    package_name: Google::Cloud::Monitoring::V3
   php:
     package_name: Google\Cloud\Monitoring\V3
 interfaces:

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -9,7 +9,7 @@ language_settings:
   csharp:
     package_name: Google.Pubsub.V1
   ruby:
-    package_name: Google::Pubsub::V1
+    package_name: Google::Cloud::Pubsub::V1
   php:
     package_name: Google\Cloud\PubSub\V1
   nodejs:


### PR DESCRIPTION
- Add 'Cloud' to Ruby packages.
  The decision is that gapic files will be under cloud, so
  change the package name to do so.
- Replace 'gcloud-ruby' by 'google-cloud-ruby'
  The repository name change happened quite recently.