### PR TITLE
Renaming 'cloudtrace' to 'trace'

### DIFF
--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -10,10 +10,10 @@ common:
     - ${REPOROOT}/googleapis/google/devtools/cloudtrace/v1/trace_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
 java:
-  final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-cloudtrace
+  final_repo_dir: ${REPOROOT}/gcloud-java/gcloud-java-trace
 python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloudtrace
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-trace
 ruby:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-cloudtrace
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-ruby-trace
 nodejs:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-cloudtrace
+  final_repo_dir: ${REPOROOT}/artman/output/gcloud-node-trace

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -1,11 +1,11 @@
 type: com.google.api.codegen.ConfigProto
 language_settings:
   java:
-    package_name: com.google.cloud.cloudtrace.spi.v1
+    package_name: com.google.cloud.trace.spi.v1
   python:
-    package_name: google.cloud.cloudtrace.v1
+    package_name: google.cloud.trace.v1
   ruby:
-    package_name: Google::Cloudtrace::V1
+    package_name: Google::Cloud::Trace::V1
 interfaces:
 - name: google.devtools.cloudtrace.v1.TraceService
   retry_codes_def:


### PR DESCRIPTION
Using the name 'cloudtrace' is redundant. Anyway, the official name of
the service is "Stackdriver Trace."