### PR TITLE
Remove generate_samples flag in gapic yaml for datastore api

### DIFF
--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -1,5 +1,4 @@
 type: com.google.api.codegen.ConfigProto
-generate_samples: true
 language_settings:
   java:
     package_name: com.google.cloud.datastore.spi.v1


### PR DESCRIPTION
Please refer to https://github.com/googleapis/toolkit/pull/447 #120 