### PR TITLE
Fix required_parameters of datastore APIs

### DIFF
--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -54,8 +54,6 @@ interfaces:
     - project_id
     - partition_id
     - read_options
-    - query
-    - gql_query
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -82,7 +80,6 @@ interfaces:
     required_fields:
     - project_id
     - mode
-    - transaction
     - mutations
     request_object_method: true
     retry_codes_name: non_idempotent


### PR DESCRIPTION
- RunQuery -- "query" and "gql_query" are oneof. They shouldn't
  appear at the same time as the required parameters.
- Commit -- The comment says "transaction" is optional.

Related: https://github.com/googleapis/googleapis/pull/123