### PR TITLE
Fix some paths to be relative to REPOROOT

### DIFF
--- a/gapic/lang/common.yaml
+++ b/gapic/lang/common.yaml
@@ -4,23 +4,23 @@ common:
 java:
   enable_batch_generation: True
   gapic_language_yaml:
-    - ${THISDIR}/java_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/java_gapic.yaml
 python:
   gapic_language_yaml:
-    - ${THISDIR}/python_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/python_gapic.yaml
 go:
   gapic_language_yaml:
-    - ${THISDIR}/go_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/go_gapic.yaml
 csharp:
   gapic_language_yaml:
-    - ${THISDIR}/csharp_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/csharp_gapic.yaml
 php:
   enable_batch_generation: True
   gapic_language_yaml:
-    - ${THISDIR}/php_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/php_gapic.yaml
 ruby:
   gapic_language_yaml:
-    - ${THISDIR}/ruby_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/ruby_gapic.yaml
 nodejs:
   gapic_language_yaml:
-    - ${THISDIR}/nodejs_gapic.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/nodejs_gapic.yaml

--- a/gapic/lang/doc.yaml
+++ b/gapic/lang/doc.yaml
@@ -2,10 +2,10 @@ common:
   toolkit_path: ${REPOROOT}/toolkit
 python:
   gapic_language_yaml:
-    - ${THISDIR}/python_doc.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/python_doc.yaml
 ruby:
   gapic_language_yaml:
-    - ${THISDIR}/ruby_doc.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/ruby_doc.yaml
 nodejs:
   gapic_language_yaml:
-    - ${THISDIR}/nodejs_doc.yaml
+    - ${REPOROOT}/googleapis/gapic/lang/nodejs_doc.yaml


### PR DESCRIPTION
Previously they were relative to THISDIR, which is not safe when
running remotely.