### PR TITLE
Adding artman_genomics.yaml

### DIFF
--- a/gapic/api/artman_genomics.yaml
+++ b/gapic/api/artman_genomics.yaml
@@ -1,0 +1,10 @@
+common:
+  api_name: google-genomics-v1
+  proto_gen_pkg_deps:
+    - google-common-protos
+    - google-iam-v1
+  import_proto_path:
+    - ${REPOROOT}/googleapis
+  src_proto_path:
+    - ${REPOROOT}/googleapis/google/genomics/v1
+  output_dir: ${REPOROOT}/artman/output


### PR DESCRIPTION
This is necessary to generate grpc packages for genomics (they don't need VKit). 
