### PR TITLE
Move Python autogen packages to google.cloud.gapic namespace

### DIFF
--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.bigtable.spi.v2
   python:
-    package_name: google.cloud.gax.bigtable.v2
+    package_name: google.cloud.gapic.bigtable.v2
   go:
     package_name: cloud.google.com/go/bigtable/apiv2
   csharp:

--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.bigtable.spi.v2
   python:
-    package_name: google.cloud.bigtable.v2
+    package_name: google.cloud.gax.bigtable.v2
   go:
     package_name: cloud.google.com/go/bigtable/apiv2
   csharp:

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.language.spi.v1beta1
   python:
-    package_name: google.cloud.gax.language.v1beta1
+    package_name: google.cloud.gapic.language.v1beta1
   go:
     package_name: cloud.google.com/go/language/apiv1beta1
   csharp:

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.language.spi.v1beta1
   python:
-    package_name: google.cloud.language.v1beta1
+    package_name: google.cloud.gax.language.v1beta1
   go:
     package_name: cloud.google.com/go/language/apiv1beta1
   csharp:

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.speech.spi.v1beta1
   python:
-    package_name: google.cloud.gax.speech.v1beta1
+    package_name: google.cloud.gapic.speech.v1beta1
   go:
     package_name: cloud.google.com/go/speech/apiv1beta1
   csharp:

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.speech.spi.v1beta1
   python:
-    package_name: google.cloud.speech.v1beta1
+    package_name: google.cloud.gax.speech.v1beta1
   go:
     package_name: cloud.google.com/go/speech/apiv1beta1
   csharp:

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.vision.spi.v1
   python:
-    package_name: google.cloud.gax.vision.v1
+    package_name: google.cloud.gapic.vision.v1
   go:
     package_name: cloud.google.com/go/vision/apiv1
   csharp:

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.vision.spi.v1
   python:
-    package_name: google.cloud.vision.v1
+    package_name: google.cloud.gax.vision.v1
   go:
     package_name: cloud.google.com/go/vision/apiv1
   csharp:

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.datastore.spi.v1
   python:
-    package_name: google.cloud.gax.datastore.v1
+    package_name: google.cloud.gapic.datastore.v1
   go:
     package_name: cloud.google.com/go/datastore/apiv1
   csharp:

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.datastore.spi.v1
   python:
-    package_name: google.cloud.datastore.v1
+    package_name: google.cloud.gax.datastore.v1
   go:
     package_name: cloud.google.com/go/datastore/apiv1
   csharp:

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.errorreporting.spi.v1beta1
   python:
-    package_name: google.cloud.errorreporting.v1beta1
+    package_name: google.cloud.gax.errorreporting.v1beta1
   go:
     package_name: cloud.google.com/go/errorreporting/apiv1beta1
   csharp:

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.errorreporting.spi.v1beta1
   python:
-    package_name: google.cloud.gax.errorreporting.v1beta1
+    package_name: google.cloud.gapic.errorreporting.v1beta1
   go:
     package_name: cloud.google.com/go/errorreporting/apiv1beta1
   csharp:

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.trace.spi.v1
   python:
-    package_name: google.cloud.trace.v1
+    package_name: google.cloud.gax.trace.v1
   ruby:
     package_name: Google::Cloud::Trace::V1
   php:

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.trace.spi.v1
   python:
-    package_name: google.cloud.gax.trace.v1
+    package_name: google.cloud.gapic.trace.v1
   ruby:
     package_name: Google::Cloud::Trace::V1
   php:

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.logging.spi.v2
   python:
-    package_name: google.cloud.logging.v2
+    package_name: google.cloud.gax.logging.v2
   go:
     package_name: cloud.google.com/go/logging/apiv2
   csharp:

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.logging.spi.v2
   python:
-    package_name: google.cloud.gax.logging.v2
+    package_name: google.cloud.gapic.logging.v2
   go:
     package_name: cloud.google.com/go/logging/apiv2
   csharp:

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.monitoring.spi.v3
   python:
-    package_name: google.cloud.gax.monitoring.v3
+    package_name: google.cloud.gapic.monitoring.v3
   go:
     package_name: cloud.google.com/go/monitoring/apiv3
   csharp:

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.monitoring.spi.v3
   python:
-    package_name: google.cloud.monitoring.v3
+    package_name: google.cloud.gax.monitoring.v3
   go:
     package_name: cloud.google.com/go/monitoring/apiv3
   csharp:

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.pubsub.spi.v1
   python:
-    package_name: google.cloud.pubsub.v1
+    package_name: google.cloud.gax.pubsub.v1
   go:
     package_name: cloud.google.com/go/pubsub/apiv1
   csharp:

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.pubsub.spi.v1
   python:
-    package_name: google.cloud.gax.pubsub.v1
+    package_name: google.cloud.gapic.pubsub.v1
   go:
     package_name: cloud.google.com/go/pubsub/apiv1
   csharp:


### PR DESCRIPTION
Avoid conflicts with hand-written google-cloud-python code.

Updates https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2258