### PR TITLE
Change final_repo_dir for errorreporting on Ruby

### DIFF
--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -22,6 +22,6 @@ csharp:
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-errorreporting
 ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-errorreporting
+  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-error_reporting
 nodejs:
   final_repo_dir: ${REPOROOT}/gcloud-node/packages/errorreporting


### PR DESCRIPTION
We need to follow RubyGems convention which is multiword name should be separated by underscore.

errorreporting should be error_reporting