### PR TITLE
Script to correct timeouts in generated GAPIC configs

### DIFF
--- a/tools/correct_gapic_config_timeouts.py
+++ b/tools/correct_gapic_config_timeouts.py
@@ -1,0 +1,30 @@
+#! /usr/bin/python
+
+# TODO(jcanizales): What license header to use?
+
+# Requires:
+# pip install ruamel.yaml
+#
+# ruamel.yaml lets you read and write back Yaml files preserving the comments
+# and a nice layout.
+#
+# Example usage:
+# ./correct_gapic_config_timeouts.py wrong.yaml > correct.yaml
+
+import fileinput
+import ruamel.yaml
+import sys
+
+input_str = "".join(fileinput.input())
+
+# TODO(jcanizales): Abort with a nice error message if the file doesn't exist or
+# is empty.
+
+dom = ruamel.yaml.round_trip_load(input_str)
+
+for interface in dom['interfaces']:
+    for retry_def in interface['retry_params_def']:
+        retry_def['initial_rpc_timeout_millis'] = 60000
+        retry_def['max_rpc_timeout_millis'] = 60000
+
+ruamel.yaml.round_trip_dump(dom, sys.stdout)


### PR DESCRIPTION
I'm using this as part of a script that runs the whole pipeline to generate a GAPIC config. It's called after the output file is extracted from the downloaded .tar.gz.

I'm not sure where to put the overall script, but as this is an independent piece of it I guess other people can use it meanwhile.