### PR TITLE
Removing Operations from cloud_speech.yaml

### DIFF
--- a/google/cloud/speech/cloud_speech.yaml
+++ b/google/cloud/speech/cloud_speech.yaml
@@ -12,7 +12,6 @@ documentation:
 
 apis:
 - name: google.cloud.speech.v1beta1.Speech
-- name: google.longrunning.Operations
 
 authentication:
   rules:


### PR DESCRIPTION
This is breaking Java generation because the Operations methods don't have a GAPIC configuration; we aren't exposing Operations yet anyway. 