### PR TITLE
Removed _path from a path descriptor to avoid duplication

### DIFF
--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -131,8 +131,8 @@ interfaces:
   collections:
   - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: projects/{project}/metricDescriptors/{metric_descriptor_path=**}
-    entity_name: metric_descriptor_path
+  - name_pattern: projects/{project}/metricDescriptors/{metric_descriptor=**}
+    entity_name: metric_descriptor
   - name_pattern: projects/{project}/monitoredResourceDescriptors/{monitored_resource_descriptor}
     entity_name: monitored_resource_descriptor
   retry_codes_def:
@@ -216,7 +216,7 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     field_name_patterns:
-      name: metric_descriptor_path
+      name: metric_descriptor
     timeout_millis: 60000
   - name: CreateMetricDescriptor
     flattening:
@@ -244,7 +244,7 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     field_name_patterns:
-      name: metric_descriptor_path
+      name: metric_descriptor
     timeout_millis: 60000
   - name: ListTimeSeries
     flattening:


### PR DESCRIPTION
For example problems arise [here](https://github.com/googleapis/api-client-staging/blob/master/generated/nodejs/google-cloud-node/packages/monitoring/src/v3/metric_service_api.js#L165)