### PR TITLE
Use consistent pattern for api_name fields

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-bigtable-v2
+  api_name: google-cloud-bigtable-v2
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-clouddebugger-v2
+  api_name: google-cloud-debugger-v2
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-datastore-v1
+  api_name: google-cloud-datastore-v1
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-devtools-clouderrorreporting-v1beta1
+  api_name: google-cloud-error-reporting-v1beta1
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_genomics.yaml
+++ b/gapic/api/artman_genomics.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-genomics-v1
+  api_name: google-cloud-genomics-v1
   proto_gen_pkg_deps:
     - google-common-protos
     - google-iam-v1

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-iam-admin-v1
+  api_name: google-cloud-iam-admin-v1
   proto_gen_pkg_deps:
     - google-iam-v1
   import_proto_path:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-logging-v2
+  api_name: google-cloud-logging-v2
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_longrunning.yaml
+++ b/gapic/api/artman_longrunning.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-longrunning
+  api_name: google-longrunning-v1
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-monitoring-v3
+  api_name: google-cloud-monitoring-v3
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-pubsub-v1
+  api_name: google-cloud-pubsub-v1
   proto_gen_pkg_deps:
     - google-common-protos
     - google-iam-v1

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: google-devtools-cloudtrace-v1
+  api_name: google-cloud-trace-v1
   proto_gen_pkg_deps:
     - google-common-protos
   import_proto_path:


### PR DESCRIPTION
This directly determines Python package names, which is visible to our
users.