### PR TITLE
Go: Disable iam admin Get/Set/Test methods

### DIFF
--- a/google/iam/admin/v1/iam_gapic.yaml
+++ b/google/iam/admin/v1/iam_gapic.yaml
@@ -195,6 +195,10 @@ interfaces:
     field_name_patterns:
       resource: service_account
     timeout_millis: 60000
+    surface_treatments:
+    - include_languages:
+      - go
+      visibility: DISABLED
   - name: SetIamPolicy
     flattening:
       groups:
@@ -210,6 +214,10 @@ interfaces:
     field_name_patterns:
       resource: service_account
     timeout_millis: 60000
+    surface_treatments:
+    - include_languages:
+      - go
+      visibility: DISABLED
   - name: TestIamPermissions
     flattening:
       groups:
@@ -225,6 +233,10 @@ interfaces:
     field_name_patterns:
       resource: service_account
     timeout_millis: 60000
+    surface_treatments:
+    - include_languages:
+      - go
+      visibility: DISABLED
   - name: QueryGrantableRoles
     flattening:
       groups:


### PR DESCRIPTION
This commit disable iam admin's GetIamPolicy, SetIamPolicy,
and TestIamPermissions.

These methods are to be handwritten later.

Update https://github.com/GoogleCloudPlatform/google-cloud-go/issues/340

This also affects https://code-review.googlesource.com/#/c/8291/ . I would rather 8291 lands first to reduce churn.