### PR TITLE
Setting required_constructor_params for LRO, other

### DIFF
--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -11,7 +11,6 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-  enable_batch_generation: False
 java:
   final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-debugger
 python:

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -11,7 +11,7 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-  enable_batch_generation: True
+  enable_batch_generation: False
 java:
   final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-debugger
 python:

--- a/gapic/api/artman_functions.yaml
+++ b/gapic/api/artman_functions.yaml
@@ -13,7 +13,6 @@ common:
     - ${REPOROOT}/googleapis/google/cloud/functions/v1beta2/functions_gapic.yaml
 java:
   final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-functions
-  enable_batch_generation: True
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-functions
 go:
@@ -25,7 +24,6 @@ ruby:
   skip_packman: True
 php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-functions
-  enable_batch_generation: True
 nodejs:
   final_repo_dir: ${REPOROOT}/google-cloud-node/packages/functions
   skip_packman: True

--- a/google/cloud/functions/v1beta2/functions_gapic.yaml
+++ b/google/cloud/functions/v1beta2/functions_gapic.yaml
@@ -1,7 +1,7 @@
 type: com.google.api.codegen.ConfigProto
 language_settings:
   java:
-    package_name: com.google.cloud.cloud.functions.spi.v1beta2
+    package_name: com.google.cloud.functions.spi.v1beta2
   python:
     package_name: google.cloud.functions.v1beta2
   go:

--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: gax-google-longrunning
 interfaces:
 - name: google.longrunning.Operations
+  required_constructor_params:
+  - service_address
+  - scopes
   collections:
   - name_pattern: operations/{operation_path=**}
     entity_name: operation_path


### PR DESCRIPTION
Other:

- Turning off batch generation for APIs that are not ready yet.
- Fixing the java package of Google Cloud Functions