### PR TITLE
Go: Properly set method visibility

### DIFF
--- a/google/iam/admin/v1/iam_gapic.yaml
+++ b/google/iam/admin/v1/iam_gapic.yaml
@@ -198,7 +198,7 @@ interfaces:
     surface_treatments:
     - include_languages:
       - go
-      visibility: DISABLED
+      visibility: PRIVATE
   - name: SetIamPolicy
     flattening:
       groups:
@@ -217,7 +217,7 @@ interfaces:
     surface_treatments:
     - include_languages:
       - go
-      visibility: DISABLED
+      visibility: PRIVATE
   - name: TestIamPermissions
     flattening:
       groups:
@@ -233,10 +233,6 @@ interfaces:
     field_name_patterns:
       resource: service_account
     timeout_millis: 60000
-    surface_treatments:
-    - include_languages:
-      - go
-      visibility: DISABLED
   - name: QueryGrantableRoles
     flattening:
       groups:


### PR DESCRIPTION
This is a followup to https://github.com/googleapis/googleapis/pull/173
This commit partially reverts it by setting TestIamPermissions back to
public.
It also make {Get,Set}IamPolicy private instead of deleting them,
to make the hand-written version easier.