### PR TITLE
Adding license config to GAPIC config files

### DIFF
--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -12,6 +12,9 @@ language_settings:
     package_name: Google::Cloud::Bigtable::V2
   php:
     package_name: Google\Cloud\Bigtable\V2
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.bigtable.v2.Bigtable
   collections:

--- a/google/cloud/functions/v1beta2/functions_gapic.yaml
+++ b/google/cloud/functions/v1beta2/functions_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: Google\Cloud\Functions\V1beta2
   nodejs:
     package_name: '@google-cloud/functions'
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.functions.v1beta2.CloudFunctionsService
   collections:

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: Google\Cloud\Language\V1Beta1
   nodejs:
     package_name: "@google-cloud/language"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.language.v1beta1.LanguageService
   collections: []

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: Google\Cloud\Speech\V1beta1
   nodejs:
     package_name: "@google-cloud/speech"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.speech.v1beta1.Speech
   collections: []

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -15,6 +15,9 @@ language_settings:
     package_name: Google\Cloud\Vision\V1
   nodejs:
     package_name: "@google-cloud/vision"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.vision.v1.ImageAnnotator
   collections: []

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: Google\Cloud\Datastore\V1
   nodejs:
     package_name: "@google-cloud/datastore"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.datastore.v1.Datastore
   collections: []

--- a/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
+++ b/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
@@ -15,6 +15,9 @@ language_settings:
     package_name: Google\Cloud\Debugger\V2
   nodejs:
     package_name: '@google-cloud/debugger'
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.devtools.clouddebugger.v2.Debugger2
   collections: []

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: Google\Cloud\Errorreporting\V1beta1
   nodejs:
     package_name: "@google-cloud/errorreporting"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.devtools.clouderrorreporting.v1beta1.ErrorGroupService
   collections:

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -15,6 +15,9 @@ language_settings:
     domain_layer_location: cloud.google.com/go/trace
   csharp:
     package_name: Google.Devtools.Cloudtrace.V1
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.devtools.cloudtrace.v1.TraceService
   retry_codes_def:

--- a/google/iam/admin/v1/iam_gapic.yaml
+++ b/google/iam/admin/v1/iam_gapic.yaml
@@ -14,6 +14,9 @@ language_settings:
     package_name: Google\Cloud\Iam\Admin\V1
   nodejs:
     package_name: '@google-cloud/iam'
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.iam.admin.v1.IAM
   collections:

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -15,6 +15,9 @@ language_settings:
     package_name: Google\Cloud\Logging\V2
   nodejs:
     package_name: "@google-cloud/logging"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.logging.v2.ConfigServiceV2
   collections:

--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -12,6 +12,9 @@ language_settings:
     package_name: Google\Longrunning
   nodejs:
     package_name: gax-google-longrunning
+license_header:
+  copyright_file: copyright-google.txt
+  file: license-header-bsd-3-clause.txt
 interfaces:
 - name: google.longrunning.Operations
   required_constructor_params:

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -12,6 +12,9 @@ language_settings:
     package_name: Google::Cloud::Monitoring::V3
   php:
     package_name: Google\Cloud\Monitoring\V3
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.monitoring.v3.GroupService
   collections:

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -15,6 +15,9 @@ language_settings:
     package_name: Google\Cloud\PubSub\V1
   nodejs:
     package_name: "@google-cloud/pubsub"
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.pubsub.v1.Subscriber
   collections:


### PR DESCRIPTION
Note: google/longrunning/longrunning_gapic.yaml is the odd one out (BSD license instead of Apache).

Coordinates with https://github.com/googleapis/toolkit/pull/676 . 