### PR TITLE
Make cloudtrace::PatchTraces idempotent

### DIFF
--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -43,7 +43,7 @@ interfaces:
     required_fields:
       - project_id
       - traces
-    retry_codes_name: non_idempotent
+    retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 30000
     request_object_method: true


### PR DESCRIPTION
According to the trace team, PatchTraces can be safely retried.

Fixes #170.