### PR TITLE
Add smoke test config

### DIFF
--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -22,7 +22,7 @@ interfaces:
   smoke_test:
     method: AnalyzeSentiment
     init_fields:
-      - document.type
+    - document.type
   collections: []
   retry_codes_def:
   - name: idempotent

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -19,6 +19,10 @@ license_header:
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.language.v1beta1.LanguageService
+  smoke_test:
+    method: AnalyzeSentiment
+    init_fields:
+      - document.type
   collections: []
   retry_codes_def:
   - name: idempotent

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -22,10 +22,10 @@ interfaces:
   smoke_test:
     method: SyncRecognize
     init_fields:
-      - config.language_code="en-US"
-      - config.sample_rate=44100
-      - config.encoding
-      - audio.uri="gs://gapic-toolkit/hello.flac"
+    - config.language_code="en-US"
+    - config.sample_rate=44100
+    - config.encoding
+    - audio.uri="gs://gapic-toolkit/hello.flac"
   collections: []
   retry_codes_def:
   - name: idempotent

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -19,6 +19,13 @@ license_header:
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.speech.v1beta1.Speech
+  smoke_test:
+    method: SyncRecognize
+    init_fields:
+      - config.language_code="en-US"
+      - config.sample_rate=44100
+      - config.encoding
+      - audio.uri="gs://gapic-toolkit/hello.flac"
   collections: []
   retry_codes_def:
   - name: idempotent

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -23,7 +23,7 @@ interfaces:
   smoke_test:
     method: BatchAnnotateImages
     init_fields:
-      - requests
+    - requests
   collections: []
   retry_codes_def:
   - name: idempotent

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -20,6 +20,10 @@ license_header:
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.vision.v1.ImageAnnotator
+  smoke_test:
+    method: BatchAnnotateImages
+    init_fields:
+      - requests
   collections: []
   retry_codes_def:
   - name: idempotent

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -66,6 +66,11 @@ interfaces:
       group.name: group
     timeout_millis: 60000
 - name: google.devtools.clouderrorreporting.v1beta1.ReportErrorsService
+  smoke_test:
+    method: ReportErrorEvent
+    init_fields:
+      - project_name%project=$PROJECT_ID
+      - event.message="[MESSAGE]"
   collections:
   - name_pattern: projects/{project}
     entity_name: project

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -69,8 +69,8 @@ interfaces:
   smoke_test:
     method: ReportErrorEvent
     init_fields:
-      - project_name%project=$PROJECT_ID
-      - event.message="[MESSAGE]"
+    - project_name%project=$PROJECT_ID
+    - event.message="[MESSAGE]"
   collections:
   - name_pattern: projects/{project}
     entity_name: project

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -20,6 +20,10 @@ license_header:
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.devtools.cloudtrace.v1.TraceService
+  smoke_test:
+    method: ListTraces
+    init_fields:
+      - project_id=$PROJECT_ID
   retry_codes_def:
   - name: idempotent
     retry_codes:

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -23,7 +23,7 @@ interfaces:
   smoke_test:
     method: ListTraces
     init_fields:
-      - project_id=$PROJECT_ID
+    - project_id=$PROJECT_ID
   retry_codes_def:
   - name: idempotent
     retry_codes:

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -218,6 +218,10 @@ interfaces:
     field_name_patterns:
       metric_name: metric
 - name: google.logging.v2.LoggingServiceV2
+  smoke_test:
+    method: WriteLogEntries
+    init_fields:
+      - entries
   collections:
   - name_pattern: projects/{project}
     entity_name: parent

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -221,7 +221,7 @@ interfaces:
   smoke_test:
     method: WriteLogEntries
     init_fields:
-      - entries
+    - entries
   collections:
   - name_pattern: projects/{project}
     entity_name: parent

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -131,6 +131,10 @@ interfaces:
       name: group
     timeout_millis: 60000
 - name: google.monitoring.v3.MetricService
+  smoke_test:
+    method: ListMonitoredResourceDescriptors
+    init_fields:
+      - name=$PROJECT_ID
   collections:
   - name_pattern: projects/{project}
     entity_name: project

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -134,7 +134,7 @@ interfaces:
   smoke_test:
     method: ListMonitoredResourceDescriptors
     init_fields:
-      - name=$PROJECT_ID
+    - name=$PROJECT_ID
   collections:
   - name_pattern: projects/{project}
     entity_name: project

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -244,6 +244,11 @@ interfaces:
       - go
       visibility: DISABLED
 - name: google.pubsub.v1.Publisher
+  smoke_test:
+    method: CreateTopic
+    init_fields:
+      - name%project=$PROJECT_ID
+      - name%topic="smoketesttopic-$RANDOM"
   collections:
   - name_pattern: projects/{project}
     entity_name: project

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -247,8 +247,8 @@ interfaces:
   smoke_test:
     method: CreateTopic
     init_fields:
-      - name%project=$PROJECT_ID
-      - name%topic="smoketesttopic-$RANDOM"
+    - name%project=$PROJECT_ID
+    - name%topic="smoketesttopic-$RANDOM"
   collections:
   - name_pattern: projects/{project}
     entity_name: project


### PR DESCRIPTION
The following APIs will have the smoke test config:
- Language
- Speech
- Vision
- ErrorReporting
- Trace
- Logging
- Monitoring
- Pubsub

 TODO: Support enum init values in gapic config: https://github.com/googleapis/toolkit/issues/733