### PR TITLE
Update logging ListLogEntries to use resource_names

### DIFF
--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -285,11 +285,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - project_ids
+        - resource_names
         - filter
         - order_by
     required_fields:
-    - project_ids
+    - resource_names
     request_object_method: true
     page_streaming:
       request:


### PR DESCRIPTION
The project_id field for ListLogEntries is deprecated, and is replaced by resource_names. We should adjust our flattened surfaces to use resource_names instead of project_ids.

Request for logging PHP here: https://github.com/GoogleCloudPlatform/google-cloud-php/pull/235