### PR TITLE
Rename packagename pattern for nodejs.

### DIFF
--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -12,6 +12,9 @@ language_settings:
     package_name: Google::Cloud::Bigtable::V2
   php:
     package_name: Google\Cloud\Bigtable\V2
+  nodejs:
+    package_name: bigtable.v2
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/cloud/functions/v1beta2/functions_gapic.yaml
+++ b/google/cloud/functions/v1beta2/functions_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Functions\V1beta2
   nodejs:
-    package_name: '@google-cloud/functions'
+    package_name: functions.v1beta2
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/cloud/language/v1/language_gapic.yaml
+++ b/google/cloud/language/v1/language_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Language\V1
   nodejs:
-    package_name: "@google-cloud/language"
+    package_name: language.v1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Language\V1Beta1
   nodejs:
-    package_name: "@google-cloud/language"
+    package_name: language.v1beta1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Speech\V1beta1
   nodejs:
-    package_name: "@google-cloud/speech"
+    package_name: speech.v1beta1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -14,7 +14,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Vision\V1
   nodejs:
-    package_name: "@google-cloud/vision"
+    package_name: vision.v1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Datastore\V1
   nodejs:
-    package_name: "@google-cloud/datastore"
+    package_name: datastore.v1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
+++ b/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
@@ -14,7 +14,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Debugger\V2
   nodejs:
-    package_name: '@google-cloud/debugger'
+    package_name: debugger.v2
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Errorreporting\V1beta1
   nodejs:
-    package_name: "@google-cloud/errorreporting"
+    package_name: errorreporting.v1beta1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -9,7 +9,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Trace\V1
   nodejs:
-    package_name: "@google-cloud/trace"
+    package_name: trace.v1
+    domain_layer_location: google-cloud
   go:
     package_name: cloud.google.com/go/trace/apiv1
     domain_layer_location: cloud.google.com/go/trace

--- a/google/iam/admin/v1/iam_gapic.yaml
+++ b/google/iam/admin/v1/iam_gapic.yaml
@@ -13,7 +13,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Iam\Admin\V1
   nodejs:
-    package_name: '@google-cloud/iam'
+    package_name: iam.v1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -14,7 +14,8 @@ language_settings:
   php:
     package_name: Google\Cloud\Logging\V2
   nodejs:
-    package_name: "@google-cloud/logging"
+    package_name: logging.v2
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -11,7 +11,7 @@ language_settings:
   php:
     package_name: Google\Longrunning
   nodejs:
-    package_name: gax-google-longrunning
+    package_name: longrunning
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-bsd-3-clause.txt

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -12,6 +12,9 @@ language_settings:
     package_name: Google::Cloud::Monitoring::V3
   php:
     package_name: Google\Cloud\Monitoring\V3
+  nodejs:
+    package_name: monitoring.v3
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -14,7 +14,8 @@ language_settings:
   php:
     package_name: Google\Cloud\PubSub\V1
   nodejs:
-    package_name: "@google-cloud/pubsub"
+    package_name: pubsub.v1
+    domain_layer_location: google-cloud
 license_header:
   copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt


### PR DESCRIPTION
See googleapis/toolkit#757 for why it's necessary.