### PR TITLE
Added longrunning metdata to cloud speech gapic yaml.

### DIFF
--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -72,6 +72,7 @@ interfaces:
     timeout_millis: 60000
     long_running:
       return_type: google.cloud.speech.v1beta1.AsyncRecognizeResponse
+      metadata_type: google.cloud.speech.v1beta1.AsyncRecognizeMetdata
   - name: StreamingRecognize
     retry_codes_name: non_idempotent
     retry_params_name: default


### PR DESCRIPTION
Needs to be fixed as a result of [toolkit/722](https://github.com/googleapis/toolkit/pull/772).