### PR TITLE
Removing collection config for operation_path

### DIFF
--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -20,9 +20,6 @@ interfaces:
   required_constructor_params:
   - service_address
   - scopes
-  collections:
-  - name_pattern: operations/{operation_path=**}
-    entity_name: operation_path
   retry_codes_def:
   - name: idempotent
     retry_codes:
@@ -50,8 +47,6 @@ interfaces:
     request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
-    field_name_patterns:
-      name: operation_path
     timeout_millis: 60000
   - name: ListOperations
     flattening:
@@ -83,8 +78,6 @@ interfaces:
     request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
-    field_name_patterns:
-      name: operation_path
     timeout_millis: 60000
   - name: DeleteOperation
     flattening:
@@ -96,6 +89,4 @@ interfaces:
     request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
-    field_name_patterns:
-      name: operation_path
     timeout_millis: 60000


### PR DESCRIPTION
The APIs that use longrunning as a mix-in can use any path
of their choosing.