### PR TITLE
Removing validation for log, parent, and sync resource names

### DIFF
--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -62,6 +62,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       parent: parent
+    resource_name_treatment: NONE
   - name: GetSink
     flattening:
       groups:
@@ -75,6 +76,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       sink_name: sink
+    resource_name_treatment: NONE
   - name: CreateSink
     flattening:
       groups:
@@ -90,6 +92,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       parent: parent
+    resource_name_treatment: NONE
   - name: UpdateSink
     flattening:
       groups:
@@ -105,6 +108,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       sink_name: sink
+    resource_name_treatment: NONE
   - name: DeleteSink
     flattening:
       groups:
@@ -118,6 +122,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       sink_name: sink
+    resource_name_treatment: NONE
 - name: google.logging.v2.MetricsServiceV2
   collections:
   - name_pattern: projects/{project}
@@ -161,11 +166,14 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       parent: parent
+    resource_name_treatment: NONE
   - name: GetLogMetric
     flattening:
       groups:
       - parameters:
         - metric_name
+        parameter_resource_name_treatment:
+          metric_name: VALIDATE
     required_fields:
     - metric_name
     request_object_method: false
@@ -174,6 +182,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       metric_name: metric
+    resource_name_treatment: NONE
   - name: CreateLogMetric
     flattening:
       groups:
@@ -189,12 +198,15 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       parent: parent
+    resource_name_treatment: NONE
   - name: UpdateLogMetric
     flattening:
       groups:
       - parameters:
         - metric_name
         - metric
+        parameter_resource_name_treatment:
+          metric_name: VALIDATE
     required_fields:
     - metric_name
     - metric
@@ -204,11 +216,14 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       metric_name: metric
+    resource_name_treatment: NONE
   - name: DeleteLogMetric
     flattening:
       groups:
       - parameters:
         - metric_name
+        parameter_resource_name_treatment:
+          metric_name: VALIDATE
     required_fields:
     - metric_name
     request_object_method: false
@@ -217,6 +232,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       metric_name: metric
+    resource_name_treatment: NONE
 - name: google.logging.v2.LoggingServiceV2
   smoke_test:
     method: WriteLogEntries
@@ -267,6 +283,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       log_name: log
+    resource_name_treatment: NONE
   - name: WriteLogEntries
     flattening:
       groups:
@@ -283,6 +300,7 @@ interfaces:
     timeout_millis: 30000
     field_name_patterns:
       log_name: log
+    resource_name_treatment: NONE
   - name: ListLogEntries
     flattening:
       groups:
@@ -303,6 +321,7 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: list
     timeout_millis: 30000
+    resource_name_treatment: NONE
   - name: ListMonitoredResourceDescriptors
     request_object_method: true
     page_streaming:
@@ -315,3 +334,4 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 30000
+    resource_name_treatment: NONE


### PR DESCRIPTION
* metric_name still has only one format, so it will still be validated. 
