### PR TITLE
Add configuration for PackageMetadataGen

### DIFF
--- a/gapic/lang/common.yaml
+++ b/gapic/lang/common.yaml
@@ -1,6 +1,10 @@
 common:
   toolkit_path: ${REPOROOT}/toolkit
   staging_repo_dir: ${REPOROOT}/api-client-staging/generated
+  # common gRPC package generation parameters
+  package_dependencies_yaml: ${REPOROOT}/googleapis/gapic/packaging/dependencies.yaml
+  package_defaults_yaml: ${REPOROOT}/googleapis/gapic/packaging/api_defaults.yaml
+  common_protos_yaml: ${REPOROOT}/googleapis/gapic/packaging/common_protos.yaml
 java:
   enable_batch_generation: True
   gapic_language_yaml:

--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -1,0 +1,29 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Provides default values used as metadata when constructing various packages.
+
+author: Google Inc
+description: a grpc-based api
+email: googleapis-packages@google.com
+github_user_uri: https://github.com/googleapis
+homepage: https://github.com/googleapis/googleapis
+license: Apache-2.0
+semver:
+  # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
+  #       publishing some 1.0.x versions to pypi already. They are now
+  #       deleted but files still exist on the pypi servers and can prevent
+  #       us from using the version number again.
+  python: '0.14.0'

--- a/gapic/packaging/common_protos.yaml
+++ b/gapic/packaging/common_protos.yaml
@@ -1,0 +1,36 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# packages are the directories in the Google APIs repo that contain shared
+# protos.  name is the path below google, version is an optional path below
+# name.
+packages:
+  -
+    name: 'api'
+    version: ''
+  -
+    name: 'longrunning'
+    version: ''
+  -
+    name: 'rpc'
+    version: ''
+  -
+    name: 'type'
+    version: ''
+  -
+    name: 'logging/type'
+    version: ''
+
+# semver is the semantic version of the common protos package.
+semver: 1.5.0

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -1,0 +1,37 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Configures the version of the dependencies of various generated packages, and
+# related information.
+
+auth:
+  python:
+    version: '2.0.0'
+    next_version: '4.0dev'
+
+grpc:
+  python:
+    version: '1.0.0'
+    next_version: '2.0dev'
+
+protobuf:
+  python:
+    version: '3.0.0'
+    next_version: '4.0dev'
+
+googleapis_common_protos:
+  python:
+    version: '1.5.0'
+    next_version: '2.0dev'


### PR DESCRIPTION
Copies some files from Packman to googleapis, and passes them to
Artman's pipeline kwargs.

Once all languages stop using Packman, we can delete the duplicate copies in that repo.