### PR TITLE
Adding Beta release level to Logging Java

### DIFF
--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -2,6 +2,7 @@ type: com.google.api.codegen.ConfigProto
 language_settings:
   java:
     package_name: com.google.cloud.logging.spi.v2
+    release_level: BETA
   python:
     package_name: google.cloud.gapic.logging.v2
   go:


### PR DESCRIPTION
Making use of https://github.com/googleapis/toolkit/pull/838 for Logging Java.