### PR TITLE
Add configuration for Logging external types

### DIFF
--- a/gapic/core/artman_logging_types.yaml
+++ b/gapic/core/artman_logging_types.yaml
@@ -1,0 +1,16 @@
+common:
+  api_name: service-logging-types
+  api_version: v1
+  organization_name: google
+  proto_gen_pkg_deps:
+    - google-common-protos
+  import_proto_path:
+    - ${REPOROOT}/googleapis
+  src_proto_path:
+    # Remaining AuditData types should be added here. See
+    #   https://github.com/googleapis/googleapis/issues/187
+    - ${REPOROOT}/googleapis/google/appengine/logging/v1
+    - ${REPOROOT}/googleapis/google/appengine/legacy
+  service_yaml:
+    - ${REPOROOT}/googleapis/google/logging/logging_external_types.yaml
+  output_dir: ${REPOROOT}/artman/output

--- a/google/logging/logging_external_types.yaml
+++ b/google/logging/logging_external_types.yaml
@@ -1,0 +1,13 @@
+# This is used only to generate a gRPC package for logging types not
+# present in the Stackdriver Logging client library package itself;
+# the client libraries depend on the this package to decode Logging
+# responses of these types.
+
+type: google.api.Service
+config_version: 2
+name: logging.googleapis.com
+title: Stackdriver Logging External Types
+
+types:
+- name: google.appengine.logging.v1.RequestLog
+- name: google.appengine.legacy.AuditData


### PR DESCRIPTION
Note that because Python gRPC metadata generation now uses toolkit and
is build on api-compiler, a service config file is required. This
config is used only to generate the gRPC package metadata.

Updates https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2572
Updates https://github.com/googleapis/googleapis/issues/187

cc: @ethanbao regarding addition of this new service config