### PR TITLE
Increase the total timeout for streamingRecognize to 190 seconds.

### DIFF
--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -77,4 +77,4 @@ interfaces:
   - name: StreamingRecognize
     retry_codes_name: non_idempotent
     retry_params_name: default
-    timeout_millis: 60000
+    timeout_millis: 190000


### PR DESCRIPTION
There are some error reports about gRPC deadline is too short
(see https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1894)

According to https://cloud.google.com/speech/limits#content,
the streamingRecognize method has the limit of ~1 minutes at API level,
and based on the error message, the total timeout should be around
185 seconds (60 seconds * 3 + 5 seconds). To make a little buffer,
this PR sets the timeout to be 190 seconds.