### PR TITLE
Update config files to use consistent terminology

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -19,7 +19,7 @@ author: Google Inc
 email: googleapis-packages@google.com
 homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
-package_version:
+generated_package_version:
   # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent

--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -16,14 +16,18 @@
 # Provides default values used as metadata when constructing various packages.
 
 author: Google Inc
-description: a grpc-based api
 email: googleapis-packages@google.com
-github_user_uri: https://github.com/googleapis
 homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
-semver:
+package_version:
   # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.14.0'
+  python:
+    lower: '0.14.0'
+    upper: '0.15dev'
+  nodejs:
+    lower: '0.7.1'
+  php:
+    lower: '0.1.0'

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -16,27 +16,44 @@
 # Configures the version of the dependencies of various generated packages, and
 # related information.
 
-auth:
+auth_version:
   python:
-    version: '2.0.0'
-    next_version: '4.0dev'
+    lower: '2.0.0'
+    upper: '4.0dev'
+  nodejs:
+    lower: '0.9.8'
 
-grpc:
+grpc_version:
   python:
-    version: '1.0.2'
-    next_version: '2.0dev'
+    lower: '1.0.2'
+    upper: '2.0dev'
+  nodejs:
+    lower: '0.15.0'
+  php:
+    lower: '0.14.1'
 
-gax:
+gax_version:
   python:
-    version: '0.15.0'
-    next_version: '0.16dev'
+    lower: '0.15.0'
+    upper: '0.16dev'
+  nodejs:
+    lower: '0.7.0'
+  php:
+    lower: '0.6.*'
 
-protobuf:
+proto_version:
   python:
-    version: '3.0.0'
-    next_version: '4.0dev'
+    lower: '3.0.0'
+    upper: '4.0dev'
+  nodejs:
+    # This is the version of ProtoBuf.js.
+    lower: '5.0.1'
+  php:
+    lower: '0.7.*'
 
-googleapis_common_protos:
+common_protos_version:
   python:
-    version: '1.5.0'
-    next_version: '2.0dev'
+    lower: '1.5.0'
+    upper: '2.0dev'
+  nodejs:
+    lower: '0.8.2'


### PR DESCRIPTION
This is a prerequisite to https://github.com/googleapis/artman/pull/131

- Also removes some old `packman` fields that are not currently used by the `toolkit` metadata generation.
- Also copies some previously hardcoded PHP configuration that was deleted from `toolkit` in https://github.com/googleapis/toolkit/pull/870 (FYI @michaelbausor)