### PR TITLE
move go artifacts to api-client-staging

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -18,7 +18,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-bigtable
 go:
-  final_repo_dir: ${REPOROOT}/gapi-bigtable-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-bigtable-v2
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-bigtable
 ruby:

--- a/gapic/api/artman_bigtable_admin.yaml
+++ b/gapic/api/artman_bigtable_admin.yaml
@@ -18,7 +18,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-bigtable-admin
 go:
-  final_repo_dir: ${REPOROOT}/gapi-bigtable-admin-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-bigtable-admin-v2
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-bigtable-admin
 ruby:

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -18,7 +18,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-debugger
 go:
-  final_repo_dir: ${REPOROOT}/gapi-debugger-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-devtools-clouddebugger-v2
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-debugger
 php:

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -18,7 +18,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-datastore
 go:
-  final_repo_dir: ${REPOROOT}/gapi-datastore-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-datastore-v1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-datastore
 ruby:

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -19,7 +19,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-errorreporting
 go:
-  final_repo_dir: ${REPOROOT}/gapi-errorreporting-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-devtools-clouderrorreporting-v1beta1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-errorreporting
 php:

--- a/gapic/api/artman_functions.yaml
+++ b/gapic/api/artman_functions.yaml
@@ -18,7 +18,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-functions
 go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-functions-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-cloud-functions-v1beta2
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-functions
 ruby:

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -18,7 +18,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-iam
 go:
-  final_repo_dir: ${REPOROOT}/gapi-iam-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-iam-admin-v1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-iam
 php:

--- a/gapic/api/artman_language.yaml
+++ b/gapic/api/artman_language.yaml
@@ -19,7 +19,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-language
 go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-language-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-cloud-language-v1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
 ruby:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -19,7 +19,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-logging
 go:
-  final_repo_dir: ${REPOROOT}/gapi-logging-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-logging-v2
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-logging
 ruby:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -22,7 +22,7 @@ php:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-monitoring
 go:
-  final_repo_dir: ${REPOROOT}/gapi-monitoring-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-monitoring-v3
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-monitoring
 ruby:

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -22,7 +22,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-pubsub
 go:
-  final_repo_dir: ${REPOROOT}/gapi-pubsub-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-pubsub-v1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-pubsub
 php:

--- a/gapic/api/artman_speech.yaml
+++ b/gapic/api/artman_speech.yaml
@@ -19,7 +19,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-speech
 go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-speech-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-cloud-speech-v1beta1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
 ruby:

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -26,4 +26,4 @@ php:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-trace
   enable_batch_generation: True
 go:
-  final_repo_dir: ${REPOROOT}/gapi-trace-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-devtools-cloudtrace-v1

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -19,7 +19,7 @@ java:
 python:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-vision
 go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-vision-go
+  final_repo_dir: ${REPOROOT}/api-client-staging/generated/go/google-cloud-vision-v1
 csharp:
   final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-vision
 ruby:


### PR DESCRIPTION
Many languages put the generated artifacts in the google-cloud-{lang}
directory under REPOROOT.
One unusual thing about Go is that the toolchain assumes all Go code to
live inside a directory named by env var GOPATH.
This path is different on each machine,
so we don't have a good default place to put the artifacts.

Knowing this, we might as well make it easier to put things into
staging repo.