### PR TITLE
New and improved GAX 0.15.6

### DIFF
--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -38,7 +38,7 @@ grpc_version:
 
 gax_version:
   python:
-    lower: '0.15.5'
+    lower: '0.15.6'
     upper: '0.16dev'
   nodejs:
     lower: '0.10.6'


### PR DESCRIPTION
Bump GAX minimum version fro, 0.15.5 to 0.15.6.