### PR TITLE
Ruby gen package version now matches packman version.

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -32,4 +32,4 @@ generated_package_version:
   php:
     lower: '0.1.0'
   ruby:
-    lower: '0.1.0'
+    lower: '0.6.8'


### PR DESCRIPTION
This was a value in packman that I ported incorrectly.