### PR TITLE
Upgrade gax-nodejs version to 0.11.0

### DIFF
--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -37,7 +37,7 @@ gax_version:
     lower: '0.15.5'
     upper: '0.16dev'
   nodejs:
-    lower: '0.10.6'
+    lower: '0.11.0'
   php:
     lower: '0.7.*'
 


### PR DESCRIPTION
The new HTTP headers increments the version.