### PR TITLE
Allow a status code of UNAVAILABLE to be retried

### DIFF
--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -29,7 +29,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/functions/v1beta2/functions_gapic.yaml
+++ b/google/cloud/functions/v1beta2/functions_gapic.yaml
@@ -31,7 +31,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/language/v1/language_gapic.yaml
+++ b/google/cloud/language/v1/language_gapic.yaml
@@ -27,7 +27,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -31,7 +31,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -34,7 +34,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -33,7 +33,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -27,7 +27,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
+++ b/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
@@ -28,7 +28,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -118,7 +119,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -34,7 +34,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -88,7 +89,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -125,7 +127,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -32,6 +32,7 @@ interfaces:
     - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/iam/admin/v1/iam_gapic.yaml
+++ b/google/iam/admin/v1/iam_gapic.yaml
@@ -33,7 +33,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -82,7 +82,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -186,7 +187,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -296,7 +298,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -26,7 +26,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -40,7 +40,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -166,7 +167,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -46,7 +46,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -372,7 +373,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/spanner/admin/database/v1/spanner_admin_database_gapic.yaml
+++ b/google/spanner/admin/database/v1/spanner_admin_database_gapic.yaml
@@ -31,7 +31,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000

--- a/google/spanner/admin/instance/v1/spanner_admin_instance_gapic.yaml
+++ b/google/spanner/admin/instance/v1/spanner_admin_instance_gapic.yaml
@@ -33,7 +33,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000

--- a/google/spanner/v1/spanner_gapic.yaml
+++ b/google/spanner/v1/spanner_gapic.yaml
@@ -31,7 +31,8 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE      
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000


### PR DESCRIPTION
This is applied to the `retry_codes` of every API.
It's only a change for non-idempotent methods; the idempotent
methods already included this in the list.