### PR TITLE
Remove RunQuery flattenings

### DIFF
--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -56,6 +56,10 @@ interfaces:
     timeout_millis: 60000
   - name: RunQuery
     # TODO: Add flattening with oneof when oneofs implemented
+    required_fields:
+    - project_id
+    - partition_id
+    - read_options
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -55,22 +55,7 @@ interfaces:
     retry_params_name: default
     timeout_millis: 60000
   - name: RunQuery
-    flattening:
-      groups:
-      - parameters:
-        - project_id
-        - partition_id
-        - read_options
-        - query
-      - parameters:
-        - project_id
-        - partition_id
-        - read_options
-        - gql_query
-    required_fields:
-    - project_id
-    - partition_id
-    - read_options
+    # TODO: Add flattening with oneof when oneofs implemented
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default


### PR DESCRIPTION
The flattening of RunQuery requires oneof support; remove the two flattenings that simulated oneof support using two overloads.

See https://github.com/googleapis/toolkit/issues/1057 for more details.