### PR TITLE
Bump internal version to 0.15.3, GAX to 0.15.7

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -25,7 +25,7 @@ generated_package_version:
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
   python:
-    lower: '0.15.1'
+    lower: '0.15.3'
     upper: '0.16dev'
   nodejs:
     lower: '0.7.1'

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -38,7 +38,7 @@ grpc_version:
 
 gax_version:
   python:
-    lower: '0.15.6'
+    lower: '0.15.7'
     upper: '0.16dev'
   nodejs:
     lower: '0.12.2'


### PR DESCRIPTION
@geigerj Hopefully another very boring PR for you.