### PR TITLE
vision: allow idempotent method to retry on INTERNAL error

### DIFF
--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -32,9 +32,10 @@ interfaces:
     retry_codes:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - INTERNAL
   - name: non_idempotent
     retry_codes:
-    - UNAVAILABLE      
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100


### PR DESCRIPTION
This reduces flakiness in Go tests.

Adding Vision POC @swcloud 