### PR TITLE
pubsub java: deprecate Pull, ModifyAckDeadline, and Acknowledge

### DIFF
--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -173,6 +173,10 @@ interfaces:
     field_name_patterns:
       subscription: subscription
     timeout_millis: 60000
+    surface_treatments:
+    - include_languages:
+      - java
+      release_level: DEPRECATED
   - name: Acknowledge
     flattening:
       groups:
@@ -189,6 +193,10 @@ interfaces:
     field_name_patterns:
       subscription: subscription
     timeout_millis: 60000
+    surface_treatments:
+    - include_languages:
+      - java
+      release_level: DEPRECATED
   - name: Pull
     flattening:
       groups:
@@ -206,6 +214,10 @@ interfaces:
     field_name_patterns:
       subscription: subscription
     timeout_millis: 60000
+    surface_treatments:
+    - include_languages:
+      - java
+      release_level: DEPRECATED
   - name: StreamingPull
     required_fields:
     - subscription


### PR DESCRIPTION
These functionalities are instead exposed in Subscriber class.

Updates GoogleCloudPlatform/google-cloud-java#1734 .