### PR TITLE
read_options in Datastore is optional

### DIFF
--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -48,7 +48,6 @@ interfaces:
         - keys
     required_fields:
     - project_id
-    - read_options
     - keys
     request_object_method: true
     retry_codes_name: idempotent
@@ -59,7 +58,6 @@ interfaces:
     required_fields:
     - project_id
     - partition_id
-    - read_options
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default


### PR DESCRIPTION
cc @garrettjonesgoogle 