### PR TITLE
Set Speech RPC timeout to 190 seconds.

### DIFF
--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -41,9 +41,9 @@ interfaces:
     initial_retry_delay_millis: 100
     retry_delay_multiplier: 1.3
     max_retry_delay_millis: 60000
-    initial_rpc_timeout_millis: 186000
+    initial_rpc_timeout_millis: 190000
     rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 186000
+    max_rpc_timeout_millis: 190000
     total_timeout_millis: 600000
   methods:
   - name: SyncRecognize

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -35,15 +35,15 @@ interfaces:
     - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
-    - UNAVAILABLE      
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
     retry_delay_multiplier: 1.3
     max_retry_delay_millis: 60000
-    initial_rpc_timeout_millis: 60000
+    initial_rpc_timeout_millis: 186000
     rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 60000
+    max_rpc_timeout_millis: 186000
     total_timeout_millis: 600000
   methods:
   - name: SyncRecognize


### PR DESCRIPTION
The gRPC timeout for speech streaming should be set to 186 seconds, not 60.

If you send an audio file and set the timeout too low, the Speech API gives you a flat-out error (see GoogleCloudPlatform/google-cloud-python#3165) if you set your timeout too low. Furthermore, the error message gives you a formula for the correct timeout (`>= {length of input file in seconds} * 3 + 5`), and then gives you a value that it tells you to use...that is wrong.

We should just set our settings so that our users do not encounter this issue. Since the maximum duration of audio files sent this way is one minute, we should just ensure we send a timeout greater than the 185 seconds that is maximally required. (Note on the above ticket that there is some goofy float conversion happening, at least in some languages, thus the intentionally sending something one second longer so that the `>=` check done by the server is guaranteed to work.)

Tagging @shinfan as eng POC for Speech and @bjwatson for a second eyeball.