### PR TITLE
Switch timeout_mills to 190000 for Speech v1

### DIFF
--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -56,7 +56,7 @@ interfaces:
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
-    timeout_millis: 60000
+    timeout_millis: 190000
   - name: LongRunningRecognize
     flattening:
       groups:
@@ -74,7 +74,7 @@ interfaces:
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default
-    timeout_millis: 60000
+    timeout_millis: 190000
     long_running:
       return_type: google.cloud.speech.v1.LongRunningRecognizeResponse
       metadata_type: google.cloud.speech.v1.LongRunningRecognizeMetadata

--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -74,7 +74,7 @@ interfaces:
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default
-    timeout_millis: 190000
+    timeout_millis: 60000
     long_running:
       return_type: google.cloud.speech.v1.LongRunningRecognizeResponse
       metadata_type: google.cloud.speech.v1.LongRunningRecognizeMetadata


### PR DESCRIPTION
More context: https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1380

cc/ @pbogle 