### PR TITLE
Made devtools/source/v1 visible to grpc generator

### DIFF
--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -9,6 +9,7 @@ common:
     - ${REPOROOT}/googleapis
   src_proto_path:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/v2
+    - ${REPOROOT}/googleapis/google/devtools/source/v1
   service_yaml:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/clouddebugger.yaml
   gapic_api_yaml:


### PR DESCRIPTION
Looks like the grpc generator is missing the source protos without this.

https://github.com/googleapis/api-client-staging/pull/207#issuecomment-291586734