### PR TITLE
Updating Service Control Operation Label Documentation for Restricted API Keys

### DIFF
--- a/google/api/servicecontrol/v1/operation.proto
+++ b/google/api/servicecontrol/v1/operation.proto
@@ -86,20 +86,20 @@ message Operation {
   //        operation happened,
   //     - `servicecontrol.googleapis.com/android_cert_fingerprint` describing
   //        the SHA-1 signing-certificate fingerprint of the API request, used
-  //        when the provided api key is restricted to certain Android apps,
+  //        when the provided API key is restricted to certain Android apps,
   //     - `servicecontrol.googleapis.com/android_package_name` describing the
-  //        package name of the API request, used when the provided api key is
+  //        package name of the API request, used when the provided API key is
   //        restricted to certain Android apps,
   //     - `servicecontrol.googleapis.com/caller_ip` describing the IP address 
-  //        of the API request, used when the provided api key is restricted to
+  //        of the API request, used when the provided API key is restricted to
   //        certain IP addresses, 
   //     - `servicecontrol.googleapis.com/ios_bundle_id` describing the bundle
-  //        identifier of the API request, used when the provided api key is
+  //        identifier of the API request, used when the provided API key is
   //        restricted to certain iOS apps,
   //     - `servicecontrol.googleapis.com/platform` describing the platform
   //        where the API is served (e.g. GAE, GCE, GKE),
   //     - `servicecontrol.googleapis.com/referer` describing the HTTP referrer 
-  //        of the API request, used when the provided api key is restricted to
+  //        of the API request, used when the provided API key is restricted to
   //        certain HTTP referrers, 
   //     - `servicecontrol.googleapis.com/service_agent` describing the service
   //        used to handle the API request (e.g. ESP),

--- a/google/api/servicecontrol/v1/operation.proto
+++ b/google/api/servicecontrol/v1/operation.proto
@@ -84,12 +84,27 @@ message Operation {
   // - The following labels defined by Google Cloud Platform:
   //     - `cloud.googleapis.com/location` describing the location where the
   //        operation happened,
-  //     - `servicecontrol.googleapis.com/user_agent` describing the user agent
-  //        of the API request,
+  //     - `servicecontrol.googleapis.com/android_cert_fingerprint` describing
+  //        the SHA-1 signing-certificate fingerprint of the API request, used
+  //        when the provided api key is restricted to certain Android apps,
+  //     - `servicecontrol.googleapis.com/android_package_name` describing the
+  //        package name of the API request, used when the provided api key is
+  //        restricted to certain Android apps,
+  //     - `servicecontrol.googleapis.com/caller_ip` describing the IP address 
+  //        of the API request, used when the provided api key is restricted to
+  //        certain IP addresses, 
+  //     - `servicecontrol.googleapis.com/ios_bundle_id` describing the bundle
+  //        identifier of the API request, used when the provided api key is
+  //        restricted to certain iOS apps,
+  //     - `servicecontrol.googleapis.com/platform` describing the platform
+  //        where the API is served (e.g. GAE, GCE, GKE),
+  //     - `servicecontrol.googleapis.com/referer` describing the HTTP referrer 
+  //        of the API request, used when the provided api key is restricted to
+  //        certain HTTP referrers, 
   //     - `servicecontrol.googleapis.com/service_agent` describing the service
   //        used to handle the API request (e.g. ESP),
-  //     - `servicecontrol.googleapis.com/platform` describing the platform
-  //        where the API is served (e.g. GAE, GCE, GKE).
+  //     - `servicecontrol.googleapis.com/user_agent` describing the user agent
+  //        of the API request.
   map<string, string> labels = 6;
 
   // Represents information about this operation. Each MetricValueSet


### PR DESCRIPTION
This pull request documents the required service control operation labels to use when validating restricted API keys via the check method, as documented here: https://github.com/googleapis/googleapis/issues/303. The added documentation is based on the https://github.com/cloudendpoints/endpoints-management-python project.

The documentation should also be updated here: https://cloud.google.com/service-control/reference/rest/v1/Operation.

Thanks,
Ian