### PR TITLE
prepare release 0.1.7

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -34,4 +34,4 @@ generated_package_version:
   ruby:
     lower: '0.6.8'
   java:
-    lower: '0.1.6'
+    lower: '0.1.7'

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -36,7 +36,7 @@ grpc_version:
   ruby:
     lower: '1.0'
   java:
-    lower: '1.0.1'
+    lower: '1.2.0'
 
 gax_version:
   python:
@@ -63,7 +63,7 @@ proto_version:
   ruby:
     lower: '3.0'
   java:
-    lower: '3.0.0'
+    lower: '3.2.0'
 
 # Dependencies on gRPC/proto packages referenced in the proto_deps
 # field of the Artman config.


### PR DESCRIPTION
grpc and protobuf bumped to 1.2.0 and 3.2.0 respectively

Can we roll this out before gax and google-cloud-java? Or do we need to big bang?