### PR TITLE
Cut polling interval to 20000 (1/3) for Speech v1 LRO

### DIFF
--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -78,7 +78,7 @@ interfaces:
     long_running:
       return_type: google.cloud.speech.v1.LongRunningRecognizeResponse
       metadata_type: google.cloud.speech.v1.LongRunningRecognizeMetadata
-      polling_interval_millis: 60000
+      polling_interval_millis: 20000
   - name: StreamingRecognize
     request_object_method: true
     retry_codes_name: idempotent


### PR DESCRIPTION
Long term speaking we should implement the exponential back-off to fix the issue, but this should be good for now.