### PR TITLE
Bump Python GAPIC version

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -25,7 +25,7 @@ generated_package_version:
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
   python:
-    lower: '0.15.3'
+    lower: '0.15.4'
     upper: '0.16dev'
   nodejs:
     lower: '0.7.1'


### PR DESCRIPTION
Note: approved offline by @lukesneeringer 