### PR TITLE
Expanded artman_*.yaml files, compatible with Artman 0.2.0

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -14,19 +14,38 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/bigtable/v2/bigtable_gapic.yaml
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-bigtable
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-bigtable
-go:
-  final_repo_dir: ${REPOROOT}/gapi-bigtable-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-bigtable
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-bigtable
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-bigtable
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-bigtable-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: bigtable/apiv2
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-bigtable
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-bigtable-v2
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/bigtable-v2
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v2
+    gapic_subpath: packages/bigtable/src/v2
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-bigtable
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/bigtable
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-bigtable
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-bigtable-v2
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-bigtable-v2
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-bigtable-v2
+    grpc_subpath: generated/python/proto-google-cloud-bigtable-v2
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-bigtable
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/bigtable/v2
+    gapic_subpath: google-cloud-bigtable/lib/google/cloud/bigtable/v2
   skip_packman: True

--- a/gapic/api/artman_bigtable_admin.yaml
+++ b/gapic/api/artman_bigtable_admin.yaml
@@ -14,19 +14,38 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-bigtable-admin
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-bigtable-admin
-go:
-  final_repo_dir: ${REPOROOT}/gapi-bigtable-admin-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-bigtable-admin
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-bigtable-admin
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-bigtable-admin
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-bigtable-admin-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: bigtable-admin/apiv2
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-bigtable-admin
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-bigtable-admin-v2
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/bigtable-admin-v2
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v2
+    gapic_subpath: packages/bigtable-admin/src/v2
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-bigtable-admin
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/bigtable-admin
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-bigtable-admin
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-bigtable-admin-v2
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-bigtable-admin-v2
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-bigtable-admin-v2
+    grpc_subpath: generated/python/proto-google-cloud-bigtable-admin-v2
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-bigtable-admin
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/bigtable-admin/v2
+    gapic_subpath: google-cloud-bigtable-admin/lib/google/cloud/bigtable-admin/v2
   skip_packman: True

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -9,23 +9,44 @@ common:
     - ${REPOROOT}/googleapis
   src_proto_path:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/v2
-    - ${REPOROOT}/googleapis/google/devtools/source/v1
+    - ${REPOROOT}/googleapis/google/devtools/source/v2
   service_yaml:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/clouddebugger.yaml
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-debugger
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-debugger
-go:
-  final_repo_dir: ${REPOROOT}/gapi-debugger-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-debugger
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-debugger
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-debugger
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-debugger
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-debugger-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: debugger/apiv2
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-debugger
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-debugger-v2
 nodejs:
-  final_repo_dir: ${REPOROOT}/gcloud-node/packages/debugger
+  gapic_code_dir: ${REPOROOT}/artman/output/js/debugger-v2
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v2
+    gapic_subpath: packages/debugger/src/v2
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-debugger
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-debugger-v2
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-debugger-v2
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-debugger-v2
+    grpc_subpath: generated/python/proto-google-cloud-debugger-v2
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-debugger
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/debugger/v2
+    gapic_subpath: google-cloud-debugger/lib/google/cloud/debugger/v2
+  skip_packman: True

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -14,19 +14,38 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/datastore/v1/datastore_gapic.yaml
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-datastore
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-datastore
-go:
-  final_repo_dir: ${REPOROOT}/gapi-datastore-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-datastore
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-datastore
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-datastore
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-datastore-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: datastore/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-datastore
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-datastore-v1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/datastore-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1
+    gapic_subpath: packages/datastore/src/v1
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-datastore
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/datastore
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-datastore
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-datastore-v1
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-datastore-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-datastore-v1
+    grpc_subpath: generated/python/proto-google-cloud-datastore-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-datastore
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/datastore/v1
+    gapic_subpath: google-cloud-datastore/lib/google/cloud/datastore/v1
   skip_packman: True

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -14,19 +14,38 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
+csharp:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-error-reporting
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-error-reporting-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: error-reporting/apiv1beta1
 java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-errorreporting
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-error-reporting
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-error-reporting-v1beta1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/error-reporting-v1beta1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1beta1
+    gapic_subpath: packages/error-reporting/src/v1beta1
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-error-reporting
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-error-reporting-v1beta1
   enable_batch_generation: True
 python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-errorreporting
-go:
-  final_repo_dir: ${REPOROOT}/gapi-errorreporting-go
-csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-errorreporting
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-errorreporting
-  enable_batch_generation: True
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-error-reporting-v1beta1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-error-reporting-v1beta1
+    grpc_subpath: generated/python/proto-google-cloud-error-reporting-v1beta1
 ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-error_reporting
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/errorreporting
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-error-reporting
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/error_reporting/v1beta1
+    gapic_subpath: google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1
+  skip_packman: True

--- a/gapic/api/artman_functions.yaml
+++ b/gapic/api/artman_functions.yaml
@@ -15,18 +15,18 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/cloud/functions/v1beta2/functions_gapic.yaml
 java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-functions
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-functions
 python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-functions
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-functions
 go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-functions-go
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-functions-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-functions
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-functions
 ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-functions
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-functions
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-functions
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-functions
 nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/functions
+  gapic_code_dir: ${REPOROOT}/google-cloud-node/packages/functions
   skip_packman: True

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -15,16 +15,16 @@ common:
     - ${REPOROOT}/googleapis/google/iam/admin/v1/iam_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
 java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-iam
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-iam
 python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-iam
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-python-iam
 go:
-  final_repo_dir: ${REPOROOT}/gapi-iam-go
+  gapic_code_dir: ${REPOROOT}/gapi-iam-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-iam
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-iam
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-iam
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-iam
 ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-iam
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-iam
 nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/iam
+  gapic_code_dir: ${REPOROOT}/google-cloud-node/packages/iam

--- a/gapic/api/artman_language_v1.yaml
+++ b/gapic/api/artman_language_v1.yaml
@@ -14,21 +14,38 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/cloud/language/v1/language_gapic.yaml
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-language
-  enable_batch_generation: True
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-language
-go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-language-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-language
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-language-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: language/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-language
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-language-v1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/language-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1
+    gapic_subpath: packages/language/src/v1
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-language-v1
   enable_batch_generation: True
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/language
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-language-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-language-v1
+    grpc_subpath: generated/python/proto-google-cloud-language-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-language
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/language/v1
+    gapic_subpath: google-cloud-language/lib/google/cloud/language/v1
   skip_packman: True

--- a/gapic/api/artman_language_v1beta2.yaml
+++ b/gapic/api/artman_language_v1beta2.yaml
@@ -14,21 +14,38 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/cloud/language/v1beta2/language_gapic.yaml
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-language
-  enable_batch_generation: True
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-language
-go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-language-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-language
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-language
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-language-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: language/apiv1beta2
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-language
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-language-v1beta2
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/language-v1beta2
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1beta2
+    gapic_subpath: packages/language/src/v1beta2
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-language-v1beta2
   enable_batch_generation: True
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/language
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-language-v1beta2
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-language-v1beta2
+    grpc_subpath: generated/python/proto-google-cloud-language-v1beta2
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-language
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/language/v1beta2
+    gapic_subpath: google-cloud-language/lib/google/cloud/language/v1beta2
   skip_packman: True

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -15,19 +15,38 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/logging/v2/logging_gapic.yaml
   enable_batch_generation: True
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-logging
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-logging
-go:
-  final_repo_dir: ${REPOROOT}/gapi-logging-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-logging
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-logging
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-logging
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-logging-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: logging/apiv2
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-logging
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-logging-v2
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/logging-v2
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v2
+    gapic_subpath: packages/logging/src/v2
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-logging
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/logging
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-logging
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-logging-v2
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-logging-v2
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-logging-v2
+    grpc_subpath: generated/python/proto-google-cloud-logging-v2
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-logging
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/logging/v2
+    gapic_subpath: google-cloud-logging/lib/google/cloud/logging/v2
   skip_packman: True

--- a/gapic/api/artman_longrunning.yaml
+++ b/gapic/api/artman_longrunning.yaml
@@ -14,15 +14,31 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/longrunning/longrunning_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-java:
-  final_repo_dir: ${REPOROOT}/gax-java
-python:
-  final_repo_dir: ${REPOROOT}/gax-python
 csharp:
-  final_repo_dir: ${REPOROOT}/gax-dotnet
-php:
-  final_repo_dir: ${REPOROOT}/gax-php
-ruby:
-  final_repo_dir: ${REPOROOT}/gax-ruby
+  gapic_code_dir: ${REPOROOT}/artman/output/gax-dotnet
+java:
+  gapic_code_dir: ${REPOROOT}/artman/output/gax-java
+  git_repo:
+    location: git@github.com:googleapis/gax-java.git
+    gapic_component: src/main/java/com/google/longrunning
+    gapic_subpath: src/main/java/com/google/longrunning
 nodejs:
-  final_repo_dir: ${REPOROOT}/gax-nodejs
+  gapic_code_dir: ${REPOROOT}/artman/output/gax-nodejs
+  git_repo:
+    location: git@github.com:googleapis/gax-nodejs.git
+    gapic_component: src/operation*
+    gapic_subpath: lib/operation*
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gax-php
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gax-python
+  git_repo:
+    location: git@github.com:googleapis/gax-python.git
+    gapic_component: google/gapic/longrunning
+    gapic_subpath: google/gapic/longrunning
+ruby:
+  gapic_code_dir: ${REPOROOT}/artman/output/gax-ruby
+  git_repo:
+    location: git@github.com:googleapis/gax-ruby.git
+    gapic_component: lib/google/longrunning
+    gapic_subpath: lib/google/longrunning

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -14,19 +14,38 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/monitoring/v3/monitoring_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
+csharp:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-monitoring
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-monitoring-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: monitoring/apiv3
 java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-monitoring
-  enable_batch_generation: True
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-monitoring
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-monitoring-v3
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/monitoring-v3
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v3
+    gapic_subpath: packages/monitoring/src/v3
+  skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-monitoring
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-monitoring
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-monitoring-v3
   enable_batch_generation: True
 python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-monitoring
-go:
-  final_repo_dir: ${REPOROOT}/gapi-monitoring-go
-csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-monitoring
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-monitoring-v3
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-monitoring-v3
+    grpc_subpath: generated/python/proto-google-cloud-monitoring-v3
 ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-monitoring
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/monitoring
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-monitoring
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/monitoring/v3
+    gapic_subpath: google-cloud-monitoring/lib/google/cloud/monitoring/v3
+  skip_packman: True

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -17,20 +17,40 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/pubsub/v1/pubsub_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
+  git_repo:
+    location: git@github.com:googleapis/api-client-staging.git
   enable_batch_generation: True
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-pubsub
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-pubsub
-go:
-  final_repo_dir: ${REPOROOT}/gapi-pubsub-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-pubsub
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-pubsub
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-pubsub
-  skip_packman: True
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-pubsub
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-pubsub-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: pubsub/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-pubsub
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-pubsub-v1
 nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/pubsub
+  gapic_code_dir: ${REPOROOT}/artman/output/js/pubsub-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1
+    gapic_subpath: packages/pubsub/src/v1
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-pubsub
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-pubsub-v1
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-pubsub-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-pubsub-v1
+    grpc_subpath: generated/python/proto-google-cloud-pubsub-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-pubsub
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/pubsub/v1
+    gapic_subpath: google-cloud-pubsub/lib/google/cloud/pubsub/v1
   skip_packman: True

--- a/gapic/api/artman_spanner.yaml
+++ b/gapic/api/artman_spanner.yaml
@@ -14,19 +14,38 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/spanner/v1/spanner_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-spanner
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-spanner
-go:
-  final_repo_dir: ${REPOROOT}/gapi-spanner-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-spanner
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-spanner
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-spanner
-  skip_packman: True
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-spanner
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-spanner-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: spanner/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-spanner
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-spanner-v1
 nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/spanner
+  gapic_code_dir: ${REPOROOT}/artman/output/js/spanner-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1
+    gapic_subpath: packages/spanner/src/v1
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-spanner
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-spanner-v1
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-spanner-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-spanner-v1
+    grpc_subpath: generated/python/proto-google-cloud-spanner-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-spanner
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/spanner/v1
+    gapic_subpath: google-cloud-spanner/lib/google/cloud/spanner/v1
   skip_packman: True

--- a/gapic/api/artman_spanner_admin_database.yaml
+++ b/gapic/api/artman_spanner_admin_database.yaml
@@ -15,19 +15,39 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/spanner/admin/database/v1/spanner_admin_database_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-spanner-admin-database
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-spanner-admin-database
-go:
-  final_repo_dir: ${REPOROOT}/gapi-spanner-admin-database-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-spanner-admin-database
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-spanner-admin-database
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-spanner-admin-database
-  skip_packman: True
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-spanner-admin-database
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-spanner-admin-database-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_component: cloud.google.com/go/spanner/admin/database/apiv1
+    gapic_subpath: spanner/admin/database/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-spanner-admin-database
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-spanner-admin-database-v1
 nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/spanner-admin-database
+  gapic_code_dir: ${REPOROOT}/artman/output/js/spanner-admin-database-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src
+    gapic_subpath: packages/spanner/src/admin/database
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-spanner-admin-database
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-spanner-admin-database-v1
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-spanner-admin-database-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-spanner-admin-database-v1
+    grpc_subpath: generated/python/proto-google-cloud-spanner-admin-database-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-spanner-admin-database
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/spanner-admin-database
+    gapic_subpath: google-cloud-spanner/lib/google/cloud/spanner/admin/database
   skip_packman: True

--- a/gapic/api/artman_spanner_admin_instance.yaml
+++ b/gapic/api/artman_spanner_admin_instance.yaml
@@ -15,19 +15,39 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/spanner/admin/instance/v1/spanner_admin_instance_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-spanner-admin-instance
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-spanner-admin-instance
-go:
-  final_repo_dir: ${REPOROOT}/gapi-spanner-admin-instance-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-spanner-admin-instance
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-spanner-admin-instance
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-spanner-admin-instance
-  skip_packman: True
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-spanner-admin-instance
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-spanner-admin-instance-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_component: cloud.google.com/go/spanner/admin/instance/apiv1
+    gapic_subpath: spanner/admin/instance/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-spanner-admin-instance
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-spanner-admin-instance-v1
 nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/spanner-admin-instance
+  gapic_code_dir: ${REPOROOT}/artman/output/js/spanner-admin-instance-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src
+    gapic_subpath: packages/spanner/src/admin/instance
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-spanner-admin-instance
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-spanner-admin-instance-v1
+  enable_batch_generation: True
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-spanner-admin-instance-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-spanner-admin-instance-v1
+    grpc_subpath: generated/python/proto-google-cloud-spanner-admin-instance-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-spanner-admin-instance
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/spanner-admin-instance
+    gapic_subpath: google-cloud-spanner/lib/google/cloud/spanner/admin/instance
   skip_packman: True

--- a/gapic/api/artman_speech_v1.yaml
+++ b/gapic/api/artman_speech_v1.yaml
@@ -14,22 +14,38 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/cloud/speech/v1/cloud_speech_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-speech
-  enable_batch_generation: True
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-speech
-go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-speech-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-speech
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-speech-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: speech/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-speech
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-speech-v1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/speech-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1
+    gapic_subpath: packages/speech/src/v1
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-speech-v1
   enable_batch_generation: True
-nodejs:
-  final_repo_dir: ${REPOROOT}/gcloud-node/packages/speech
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/speech
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-speech-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-speech-v1
+    grpc_subpath: generated/python/proto-google-cloud-speech-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-speech
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/speech/v1
+    gapic_subpath: google-cloud-speech/lib/google/cloud/speech/v1
   skip_packman: True

--- a/gapic/api/artman_speech_v1beta1.yaml
+++ b/gapic/api/artman_speech_v1beta1.yaml
@@ -14,22 +14,38 @@ common:
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-speech
-  enable_batch_generation: True
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-speech
-go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-speech-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-speech
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-speech
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-speech-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: speech/apiv1beta1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-speech
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-speech-v1beta1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/speech-v1beta1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1beta1
+    gapic_subpath: packages/speech/src/v1beta1
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-speech-v1beta1
   enable_batch_generation: True
-nodejs:
-  final_repo_dir: ${REPOROOT}/gcloud-node/packages/speech
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/speech
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-speech-v1beta1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-speech-v1beta1
+    grpc_subpath: generated/python/proto-google-cloud-speech-v1beta1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-speech
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/speech/v1beta1
+    gapic_subpath: google-cloud-speech/lib/google/cloud/speech/v1beta1
   skip_packman: True

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -14,17 +14,37 @@ common:
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/devtools/cloudtrace/v1/trace_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
+csharp:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-trace
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-trace-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: trace/apiv1
 java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-trace
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-trace
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-trace-v1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/trace-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_subpath: packages/trace
+  skip_packman: True
+php:
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-trace
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-trace-v1
   enable_batch_generation: True
 python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-trace
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-trace-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-trace-v1
+    grpc_subpath: generated/python/proto-google-cloud-trace-v1
 ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-trace
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/trace
-php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-trace
-  enable_batch_generation: True
-go:
-  final_repo_dir: ${REPOROOT}/gapi-trace-go
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-trace
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/trace/v1
+    gapic_subpath: google-cloud-trace/lib/google/cloud/trace/v1
+  skip_packman: True

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -11,24 +11,44 @@ common:
     - ${REPOROOT}/googleapis/google/cloud/vision/v1
   service_yaml:
     - ${REPOROOT}/googleapis/google/cloud/vision/vision.yaml
-  output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml:
     - ${REPOROOT}/googleapis/google/cloud/vision/v1/vision_gapic.yaml
+  output_dir: ${REPOROOT}/artman/output
+  git_repo:
+    location: git@github.com:googleapis/api-client-staging.git
   enable_batch_generation: True
-java:
-  final_repo_dir: ${REPOROOT}/google-cloud-java/google-cloud-vision
-python:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-python-cloud-vision
-go:
-  final_repo_dir: ${REPOROOT}/gapi-cloud-vision-go
 csharp:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-vision
-ruby:
-  final_repo_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-vision
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-cloud-vision
+go:
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-vision-go
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+    gapic_subpath: vision/apiv1
+java:
+  gapic_code_dir: ${REPOROOT}/google-cloud-java/google-cloud-vision
+  git_repo:
+    gapic_subpath: generated/java/google-cloud-vision-v1
+nodejs:
+  gapic_code_dir: ${REPOROOT}/artman/output/js/vision-v1
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-node.git
+    gapic_component: src/v1
+    gapic_subpath: packages/vision/src/v1
   skip_packman: True
 php:
-  final_repo_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-vision
+  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-vision
+  git_repo:
+    gapic_subpath: generated/php/google-cloud-vision-v1
   enable_batch_generation: True
-nodejs:
-  final_repo_dir: ${REPOROOT}/google-cloud-node/packages/vision
+python:
+  gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-vision-v1
+  git_repo:
+    gapic_subpath: generated/python/gapic-google-cloud-vision-v1
+    grpc_subpath: generated/python/proto-google-cloud-vision-v1
+ruby:
+  gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-vision
+  git_repo:
+    location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
+    gapic_component: lib/google/cloud/vision/v1
+    gapic_subpath: google-cloud-vision/lib/google/cloud/vision/v1
   skip_packman: True


### PR DESCRIPTION
This should get _most_ configuration in place for googleapis/artman#159.

I was not sure what to do about C#, since I had no staged API clients to work against, but I have reached out to Jon Skeet. Using `--publish=noop` will retain the old behavior. The rest should be mostly correct but may need some slight tinkering by the relevant language leads.