### PR TITLE
make errorreporting smoke test work

### DIFF
--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -35,7 +35,7 @@ interfaces:
     - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
-    - UNAVAILABLE      
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -80,6 +80,10 @@ interfaces:
     init_fields:
     - project_name%project=$PROJECT_ID
     - event.message="[MESSAGE]"
+    - event.service_context.service="[SERVICE]"
+    - event.context.report_location.file_path="path/to/file.lang"
+    - event.context.report_location.line_number=42
+    - event.context.report_location.function_name="meaningOfLife"
   collections:
   - name_pattern: projects/{project}
     entity_name: project
@@ -90,7 +94,7 @@ interfaces:
     - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
-    - UNAVAILABLE      
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -128,7 +132,7 @@ interfaces:
     - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
-    - UNAVAILABLE      
+    - UNAVAILABLE
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100


### PR DESCRIPTION
The location of the error must be encoded either in `event.message` or `event.context`. This PR make the smoke test not return an invalid argument error.