### PR TITLE
Revert devtools source version in cloud debugger

### DIFF
--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -9,7 +9,7 @@ common:
     - ${GOOGLEAPIS}
   src_proto_path:
     - ${GOOGLEAPIS}/google/devtools/clouddebugger/v2
-    - ${GOOGLEAPIS}/google/devtools/source/v2
+    - ${GOOGLEAPIS}/google/devtools/source/v1
   service_yaml:
     - ${GOOGLEAPIS}/google/devtools/clouddebugger/clouddebugger.yaml
   gapic_api_yaml:


### PR DESCRIPTION
This change was introduced in https://github.com/googleapis/googleapis/commit/4caf4e8d2f8f5364c3fe3bdb98593f99f461322f#diff-cf4cea30ff531b8e65dbb599aff871e7R12