### PR TITLE
output Go files to the right place

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: bigtable/apiv2
     staging:
-      gapic_subpath: google-cloud-bigtable-v2/cloud.google.com/go/bigtable/apiv2
+      gapic_subpath: generated/go/google-cloud-bigtable-v2
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-bigtable
   git_repos:

--- a/gapic/api/artman_bigtable_admin.yaml
+++ b/gapic/api/artman_bigtable_admin.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: bigtable-admin/apiv2
     staging:
-      gapic_subpath: google-bigtable-admin-v2/cloud.google.com/go/bigtable/admin/apiv2
+      gapic_subpath: generated/go/google-bigtable-admin-v2
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-bigtable-admin
   git_repos:

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -27,7 +27,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: debugger/apiv2
     staging:
-      gapic_subpath: google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2
+      gapic_subpath: generated/go/google-devtools-clouddebugger-v2
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-debugger
   git_repos:

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: datastore/apiv1
     staging:
-      gapic_subpath: google-datastore-v1/cloud.google.com/go/datastore/apiv1
+      gapic_subpath: generated/go/google-datastore-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-datastore
   git_repos:

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: error-reporting/apiv1beta1
     staging:
-      gapic_subpath: google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1
+      gapic_subpath: generated/go/google-devtools-clouderrorreporting-v1beta1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-error-reporting
   git_repos:

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -14,12 +14,21 @@ common:
   gapic_api_yaml:
     - ${GOOGLEAPIS}/google/iam/admin/v1/iam_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
+  git_repos:
+    staging:
+      location: git@github.com:googleapis/api-client-staging.git
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-iam
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gcloud-python-iam
 go:
-  gapic_code_dir: ${REPOROOT}/gapi-iam-go
+  gapic_code_dir: ${REPOROOT}/gapi-cloud-language-go
+  git_repos:
+    go:
+      location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
+      gapic_subpath: language/apiv1
+    staging:
+      gapic_subpath: generated/go/google-iam-admin-v1
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/gcloud-csharp-iam
 php:

--- a/gapic/api/artman_language_v1.yaml
+++ b/gapic/api/artman_language_v1.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: language/apiv1
     staging:
-      gapic_subpath: google-cloud-language-v1/cloud.google.com/go/language/apiv1
+      gapic_subpath: generated/go/google-cloud-language-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-language
   git_repos:

--- a/gapic/api/artman_language_v1beta2.yaml
+++ b/gapic/api/artman_language_v1beta2.yaml
@@ -25,6 +25,8 @@ go:
     go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: language/apiv1beta2
+    staging:
+      gapic_subpath: generated/go/google-cloud-language-v1beta2
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-language
   git_repos:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -27,7 +27,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: logging/apiv2
     staging:
-      gapic_subpath: google-logging-v2/cloud.google.com/go/logging/apiv2
+      gapic_subpath: generated/go/google-logging-v2
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-logging
   git_repos:

--- a/gapic/api/artman_longrunning.yaml
+++ b/gapic/api/artman_longrunning.yaml
@@ -14,6 +14,9 @@ common:
   gapic_api_yaml:
     - ${GOOGLEAPIS}/google/longrunning/longrunning_gapic.yaml
   output_dir: ${REPOROOT}/artman/output
+  git_repos:
+    staging:
+      location: git@github.com:googleapis/api-client-staging.git
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/gax-dotnet
 java:
@@ -29,6 +32,8 @@ go:
     go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: longrunning/autogen
+    staging:
+      gapic_subpath: generated/go/google-longrunning
 nodejs:
   gapic_code_dir: ${REPOROOT}/artman/output/gax-nodejs
   git_repos:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: monitoring/apiv3
     staging:
-      gapic_subpath: google-monitoring-v3/cloud.google.com/go/monitoring/v3
+      gapic_subpath: generated/go/google-monitoring-v3
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-monitoring
   git_repos:

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -30,7 +30,7 @@ go:
       gapic_subpath: pubsub/apiv1
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
     staging:
-      gapic_subpath: google-pubsub-v1/cloud.google.com/go/pubsub/apiv1
+      gapic_subpath: generated/go/google-pubsub-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-pubsub
   git_repos:

--- a/gapic/api/artman_spanner.yaml
+++ b/gapic/api/artman_spanner.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: spanner/apiv1
     staging:
-      gapic_subpath: google-spanner-admin-v1/cloud.google.com/go/spanner/admin/apiv1
+      gapic_subpath: generated/go/google-spanner-admin-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-spanner
   git_repos:

--- a/gapic/api/artman_spanner_admin_database.yaml
+++ b/gapic/api/artman_spanner_admin_database.yaml
@@ -28,7 +28,7 @@ go:
       gapic_component: cloud.google.com/go/spanner/admin/database/apiv1
       gapic_subpath: spanner/admin/database/apiv1
     staging:
-      gapic_subpath: google-spanner-admin-database-v1/cloud.google.com/go/spanner/admin/database/apiv1
+      gapic_subpath: generated/go/google-spanner-admin-database-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-spanner-admin-database
   git_repos:

--- a/gapic/api/artman_spanner_admin_instance.yaml
+++ b/gapic/api/artman_spanner_admin_instance.yaml
@@ -28,7 +28,7 @@ go:
       gapic_component: cloud.google.com/go/spanner/admin/instance/apiv1
       gapic_subpath: spanner/admin/instance/apiv1
     staging:
-      gapic_subpath: google-spanner-admin-instance-v1/cloud.google.com/go/spanner/admin/instance/apiv1
+      gapic_subpath: generated/go/google-spanner-admin-instance-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-spanner-admin-instance
   git_repos:

--- a/gapic/api/artman_speech_v1.yaml
+++ b/gapic/api/artman_speech_v1.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: speech/apiv1
     staging:
-      gapic_subpath: google-speech-v1/cloud.google.com/go/speech/apiv1
+      gapic_subpath: generated/go/google-speech-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-speech
   git_repos:

--- a/gapic/api/artman_speech_v1beta1.yaml
+++ b/gapic/api/artman_speech_v1beta1.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: speech/apiv1beta1
     staging:
-      gapic_subpath: google-speech-v1beta1/cloud.google.com/go/speech/apiv1beta1
+      gapic_subpath: generated/go/google-speech-v1beta1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-speech
   git_repos:

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -26,7 +26,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: trace/apiv1
     staging:
-      gapic_subpath: google-trace-v1/cloud.google.com/go/trace/apiv1
+      gapic_subpath: generated/go/google-trace-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-trace
   git_repos:

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -27,7 +27,7 @@ go:
       location: git@github.com:GoogleCloudPlatform/google-cloud-go.git
       gapic_subpath: vision/apiv1
     staging:
-      gapic_subpath: google-vision-v1/cloud.google.com/go/vision/apiv1
+      gapic_subpath: generated/go/google-vision-v1
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-vision
   git_repos:


### PR DESCRIPTION
Now that go_package option is defined on all protos,
protoc already knows which directory to put the files.
Just point to the root of the API.