### PR TITLE
Auto-sync to googleapis-private.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+jobs:
+  build:
+    docker:
+      - image: googleapis/git
+    steps:
+      - checkout
+      - run:
+          command: |
+            if [ "$CIRCLE_BRANCH" == "master" ]; then
+              git remote add private https://googleapis-publisher:${GITHUB_TOKEN}@github.com/googleapis/googleapis-private.git
+              git push private HEAD:master
+            fi
+    working_directory: /var/code/googleapis/


### PR DESCRIPTION
Cause any code committed to master on `googleapis/googleapis` to automatically be pushed to the private mirror also.

This is the _only_ CI task on this repo.