### PR TITLE
pubsub: use ListTopics in smoke test

### DIFF
--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -384,10 +384,9 @@ interfaces:
   lang_doc:
     java: To publish messages to a topic, see the Publisher class.
   smoke_test:
-    method: CreateTopic
+    method: ListTopics
     init_fields:
-    - name%project=$PROJECT_ID
-    - name%topic="smoketesttopic-$RANDOM"
+    - project=$PROJECT_ID
   collections:
   - name_pattern: projects/{project}
     entity_name: project


### PR DESCRIPTION
In this way, we don't leave a bunch of unused topics
in the projects.