### PR TITLE
Add core path to the batch generation

### DIFF
--- a/gapic/batch/common.yaml
+++ b/gapic/batch/common.yaml
@@ -1,4 +1,6 @@
 common:
   batch_apis: '*'
-  api_config_pattern: ${GOOGLEAPIS}/gapic/api/artman_${API_SHORT_NAME}.yaml
+  api_config_patterns:
+    - ${GOOGLEAPIS}/gapic/api/artman_${API_SHORT_NAME}.yaml
+    - ${GOOGLEAPIS}/gapic/core/artman_${API_SHORT_NAME}.yaml
   artman_language_yaml: ${GOOGLEAPIS}/gapic/lang/common.yaml


### PR DESCRIPTION
This PR enables both core and staged apis will be generated by the batch command.

Artman PR: https://github.com/googleapis/artman/pull/194