### PR TITLE
Exclude servicemanager/servicecontrol from core proto

### DIFF
--- a/gapic/core/artman_core.yaml
+++ b/gapic/core/artman_core.yaml
@@ -12,6 +12,9 @@ common:
     - ${GOOGLEAPIS}/google/longrunning
     - ${GOOGLEAPIS}/google/rpc
     - ${GOOGLEAPIS}/google/type
+  excluded_proto_path:
+    - ${GOOGLEAPIS}/google/api/servicemanagement
+    - ${GOOGLEAPIS}/google/api/servicecontrol
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml: []
   service_yaml: []


### PR DESCRIPTION
Artman PR: https://github.com/googleapis/artman/pull/197