### PR TITLE
Remove retry for UNAVAILABLE on non-idempotent calls

### DIFF
--- a/google/bigtable/v2/bigtable_gapic.yaml
+++ b/google/bigtable/v2/bigtable_gapic.yaml
@@ -29,8 +29,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/functions/v1beta2/functions_gapic.yaml
+++ b/google/cloud/functions/v1beta2/functions_gapic.yaml
@@ -31,8 +31,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/language/v1/language_gapic.yaml
+++ b/google/cloud/language/v1/language_gapic.yaml
@@ -27,8 +27,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/language/v1beta1/language_gapic.yaml
+++ b/google/cloud/language/v1beta1/language_gapic.yaml
@@ -31,8 +31,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/language/v1beta2/language_gapic.yaml
+++ b/google/cloud/language/v1beta2/language_gapic.yaml
@@ -27,8 +27,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/speech/v1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1/cloud_speech_gapic.yaml
@@ -27,8 +27,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
+++ b/google/cloud/speech/v1beta1/cloud_speech_gapic.yaml
@@ -34,8 +34,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/cloud/videointelligence/v1beta1/videointelligence_gapic.yaml
+++ b/google/cloud/videointelligence/v1beta1/videointelligence_gapic.yaml
@@ -28,8 +28,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000

--- a/google/cloud/vision/v1/vision_gapic.yaml
+++ b/google/cloud/vision/v1/vision_gapic.yaml
@@ -33,8 +33,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/datastore/v1/datastore_gapic.yaml
+++ b/google/datastore/v1/datastore_gapic.yaml
@@ -27,8 +27,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
+++ b/google/devtools/clouddebugger/v2/clouddebugger_gapic.yaml
@@ -28,8 +28,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -119,8 +118,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
+++ b/google/devtools/clouderrorreporting/v1beta1/errorreporting_gapic.yaml
@@ -34,8 +34,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -93,8 +92,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -131,8 +129,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/devtools/cloudtrace/v1/trace_gapic.yaml
+++ b/google/devtools/cloudtrace/v1/trace_gapic.yaml
@@ -31,8 +31,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/iam/admin/v1/iam_gapic.yaml
+++ b/google/iam/admin/v1/iam_gapic.yaml
@@ -33,8 +33,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -85,8 +85,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -190,8 +189,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -301,8 +299,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -31,8 +31,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/monitoring/v3/monitoring_gapic.yaml
+++ b/google/monitoring/v3/monitoring_gapic.yaml
@@ -40,8 +40,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -167,8 +166,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/privacy/dlp/v2beta1/dlp_gapic.yaml
+++ b/google/privacy/dlp/v2beta1/dlp_gapic.yaml
@@ -29,8 +29,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -49,8 +49,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   - name: pull
     retry_codes:
     - DEADLINE_EXCEEDED
@@ -407,8 +406,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/spanner/admin/database/v1/spanner_admin_database_gapic.yaml
+++ b/google/spanner/admin/database/v1/spanner_admin_database_gapic.yaml
@@ -31,8 +31,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000

--- a/google/spanner/admin/instance/v1/spanner_admin_instance_gapic.yaml
+++ b/google/spanner/admin/instance/v1/spanner_admin_instance_gapic.yaml
@@ -33,8 +33,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000

--- a/google/spanner/v1/spanner_gapic.yaml
+++ b/google/spanner/v1/spanner_gapic.yaml
@@ -31,8 +31,7 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes:
-    - UNAVAILABLE      
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 1000


### PR DESCRIPTION
Implemented by executing the following command:

find . -name '*_gapic.yaml' | xargs perl -i -p0e 's/- name: non_idempotent\n    retry_codes:\n    - UNAVAILABLE */- name: non_idempotent\n    retry_codes: \[\]/g'

(The " *" was to remove trailing whitespace that existed in some APIs)