### PR TITLE
Increase LRO timeouts

### DIFF
--- a/google/longrunning/longrunning_gapic.yaml
+++ b/google/longrunning/longrunning_gapic.yaml
@@ -38,9 +38,9 @@ interfaces:
     initial_retry_delay_millis: 100
     retry_delay_multiplier: 1.3
     max_retry_delay_millis: 60000
-    initial_rpc_timeout_millis: 20000
+    initial_rpc_timeout_millis: 90000
     rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 20000
+    max_rpc_timeout_millis: 90000
     total_timeout_millis: 600000
   methods:
   - name: GetOperation


### PR DESCRIPTION
The Video Intelligence API requires a timeout of >45s for
GetOperation. This commit increases the timeouts universally from 20s
to 90s, which shouldn't be harmful.