### PR TITLE
logging: retry on INTERNAL error

### DIFF
--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -86,8 +86,7 @@ interfaces:
     - DEADLINE_EXCEEDED
     - INTERNAL
   - name: non_idempotent
-    retry_codes:
-    - INTERNAL
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -192,8 +191,7 @@ interfaces:
     - DEADLINE_EXCEEDED
     - INTERNAL
   - name: non_idempotent
-    retry_codes:
-    - INTERNAL
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -304,8 +302,7 @@ interfaces:
     - DEADLINE_EXCEEDED
     - INTERNAL
   - name: non_idempotent
-    retry_codes:
-    - INTERNAL
+    retry_codes: []
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100

--- a/google/logging/v2/logging_gapic.yaml
+++ b/google/logging/v2/logging_gapic.yaml
@@ -84,8 +84,10 @@ interfaces:
     retry_codes:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - INTERNAL
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - INTERNAL
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -188,8 +190,10 @@ interfaces:
     retry_codes:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - INTERNAL
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - INTERNAL
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
@@ -298,8 +302,10 @@ interfaces:
     retry_codes:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - INTERNAL
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - INTERNAL
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100


### PR DESCRIPTION
Logging team communicated that this is OK.

@jba:
Want to make sure, since the email you forwareded me didn't call this out explicitly. Retrying on internal is OK even if methods are not idempotent right?