### PR TITLE
Update GAX versions for Java

### DIFF
--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -49,7 +49,11 @@ gax_version:
   ruby:
     lower: '0.8.4'
   java:
-    lower: '0.6.1'
+    lower: '1.3.1'
+
+gax_grpc_version:
+  java:
+    lower: '0.20.0'
 
 proto_version:
   python:


### PR DESCRIPTION
The GAX versions will be used by the [sample generator.](https://github.com/shinfan/toolkit/blob/75768a1d1f99f9e9eb84e4a104076659fb6420be/src/main/resources/com/google/api/codegen/java/sample.gradle.snip#L24)