### PR TITLE
java: prepare release

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -36,4 +36,4 @@ generated_package_version:
   ruby:
     lower: '0.6.8'
   java:
-    lower: '0.1.11'
+    lower: '0.1.12'

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -36,7 +36,7 @@ grpc_version:
   ruby:
     lower: '1.0'
   java:
-    lower: '1.2.0'
+    lower: '1.4.0'
 
 gax_version:
   python:
@@ -49,11 +49,11 @@ gax_version:
   ruby:
     lower: '0.8.4'
   java:
-    lower: '1.3.1'
+    lower: '1.4.1'
 
 gax_grpc_version:
   java:
-    lower: '0.20.0'
+    lower: '0.21.1'
 
 proto_version:
   python:
@@ -84,7 +84,7 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.3.1'
   java:
-    lower: '0.1.11'
+    lower: '0.1.12'
 
 google-iam-v1_version:
   python:
@@ -95,7 +95,7 @@ google-iam-v1_version:
     name_override: grpc-google-iam-v1
     lower: '0.6.8'
   java:
-    lower: '0.1.11'
+    lower: '0.1.12'
 
 api_common_version:
   java:


### PR DESCRIPTION
This release updates grpc dependency to 1.4.0.

Since protobuf dependency will be updated to 3.3.0,
common protos are also updated 0.1.12.

Updating common protos also require updating gax to 1.4.1
and gax-grpc to 0.21.1.