### PR TITLE
change package/namespace to remove 'privacy'

### DIFF
--- a/google/privacy/dlp/v2beta1/dlp_gapic.yaml
+++ b/google/privacy/dlp/v2beta1/dlp_gapic.yaml
@@ -1,17 +1,17 @@
 type: com.google.api.codegen.ConfigProto
 language_settings:
   java:
-    package_name: com.google.cloud.privacy.dlp.v2beta1
+    package_name: com.google.cloud.dlp.v2beta1
   python:
-    package_name: google.cloud.gapic.privacy.dlp.v2beta1
+    package_name: google.cloud.gapic.dlp.v2beta1
   go:
-    package_name: cloud.google.com/go/privacy/dlp/apiv2beta1
+    package_name: cloud.google.com/go/dlp/apiv2beta1
   csharp:
     package_name: Google.Cloud.Dlp.V2Beta1
   ruby:
-    package_name: Google::Cloud::Privacy::Dlp::V2beta1
+    package_name: Google::Cloud::Dlp::V2beta1
   php:
-    package_name: Google\Cloud\Privacy\Dlp\V2beta1
+    package_name: Google\Cloud\Dlp\V2beta1
   nodejs:
     package_name: dlp.v2beta1
     domain_layer_location: google-cloud


### PR DESCRIPTION
Based on recent discussion with API team, we decided to remove "privacy" in client lib package/namespace for DLP v2beta1. (We'll however not change any namespace/path for proto in this version) 