### PR TITLE
Java: bump version and prepare gRPC/proto release

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -36,4 +36,4 @@ generated_package_version:
   ruby:
     lower: '0.6.8'
   java:
-    lower: '0.1.12'
+    lower: '0.1.13'

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -84,7 +84,7 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.3.1'
   java:
-    lower: '0.1.12'
+    lower: '0.1.13'
 
 google-iam-v1_version:
   python:
@@ -95,7 +95,7 @@ google-iam-v1_version:
     name_override: grpc-google-iam-v1
     lower: '0.6.8'
   java:
-    lower: '0.1.12'
+    lower: '0.1.13'
 
 api_common_version:
   java:


### PR DESCRIPTION
bump up grpc and proto versions to 0.1.13.