### PR TITLE
Ruby: bump gax version

### DIFF
--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -47,7 +47,7 @@ gax_version:
   php:
     lower: '0.20.0'
   ruby:
-    lower: '0.8.4'
+    lower: '0.8.5'
   java:
     lower: '1.4.1'
 


### PR DESCRIPTION
Will be needed for https://github.com/googleapis/toolkit/pull/1387 and https://github.com/googleapis/gax-ruby/pull/76.