### PR TITLE
Fix PHP Namespace casing in video intelligence proto

### DIFF
--- a/google/cloud/videointelligence/v1beta1/video_intelligence.proto
+++ b/google/cloud/videointelligence/v1beta1/video_intelligence.proto
@@ -26,6 +26,7 @@ option go_package = "google.golang.org/genproto/googleapis/cloud/videointelligen
 option java_multiple_files = true;
 option java_outer_classname = "VideoIntelligenceServiceProto";
 option java_package = "com.google.cloud.videointelligence.v1beta1";
+option php_namespace = "Google\Cloud\VideoIntelligence\V1beta1";
 
 
 // Service that implements Google Cloud Video Intelligence API.

--- a/google/cloud/videointelligence/v1beta1/video_intelligence.proto
+++ b/google/cloud/videointelligence/v1beta1/video_intelligence.proto
@@ -26,7 +26,7 @@ option go_package = "google.golang.org/genproto/googleapis/cloud/videointelligen
 option java_multiple_files = true;
 option java_outer_classname = "VideoIntelligenceServiceProto";
 option java_package = "com.google.cloud.videointelligence.v1beta1";
-option php_namespace = "Google\Cloud\VideoIntelligence\V1beta1";
+option php_namespace = "Google\\Cloud\\VideoIntelligence\\V1beta1";
 
 
 // Service that implements Google Cloud Video Intelligence API.


### PR DESCRIPTION
Right now the protobuf library is generating the following namespace:

```php
namespace Google\Cloud\Videointelligence\V1beta1;
```

But it should be:


```php
namespace Google\Cloud\VideoIntelligence\V1beta1;
```

Let's take advantage of the `php_namespace` option so that this will be consistent with the other libraries.