### PR TITLE
Fix the streaming defaults

### DIFF
--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -74,6 +74,14 @@ interfaces:
     rpc_timeout_multiplier: 1
     max_rpc_timeout_millis: 12000 # 12 seconds
     total_timeout_millis: 600000 # 10 minutes
+  - name: streaming
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000 # 60 seconds
+    initial_rpc_timeout_millis: 900000 # 15 minutes
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 900000 # 15 minutes
+    total_timeout_millis: 900000 # 15 minutes
   experimental_features:
     iam_resources:
     - type: google.pubsub.v1.Subscription
@@ -233,7 +241,7 @@ interfaces:
         resources_field: received_messages
     resource_name_treatment: STATIC_TYPES
     retry_codes_name: pull
-    retry_params_name: messaging
+    retry_params_name: streaming
     field_name_patterns:
       subscription: subscription
     timeout_millis: 60000


### PR DESCRIPTION
The current default values cause the stream to be aborted and retried every 12 seconds. This also causes Pub/Sub to drop lease delays. The `streaming_pull` method should have a much, much longer keepalive.