### PR TITLE
Make encoding_type consistently optional.

### DIFF
--- a/google/cloud/language/v1/language_gapic.yaml
+++ b/google/cloud/language/v1/language_gapic.yaml
@@ -62,7 +62,6 @@ interfaces:
         - encoding_type
     required_fields:
     - document
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -75,7 +74,6 @@ interfaces:
         - encoding_type
     required_fields:
     - document
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -90,7 +88,6 @@ interfaces:
     required_fields:
     - document
     - features
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default

--- a/google/cloud/language/v1beta2/language_gapic.yaml
+++ b/google/cloud/language/v1beta2/language_gapic.yaml
@@ -62,7 +62,6 @@ interfaces:
         - encoding_type
     required_fields:
     - document
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -75,7 +74,6 @@ interfaces:
         - encoding_type
     required_fields:
     - document
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -88,7 +86,6 @@ interfaces:
         - encoding_type
     required_fields:
     - document
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -103,7 +100,6 @@ interfaces:
     required_fields:
     - document
     - features
-    - encoding_type
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default


### PR DESCRIPTION
This should be optional everywhere; it is not required by the API, and very soon the API will be able to "do the right thing" based on the headers it gets.