### PR TITLE
Bump Publish, StreamingPull maximum timeouts

### DIFF
--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -74,6 +74,14 @@ interfaces:
     rpc_timeout_multiplier: 1
     max_rpc_timeout_millis: 12000 # 12 seconds
     total_timeout_millis: 600000 # 10 minutes
+  - name: streaming_messaging
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000 # 60 seconds
+    initial_rpc_timeout_millis: 600000 # 10 minutes
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 600000 # 10 minutes
+    total_timeout_millis: 600000 # 10 minutes
   experimental_features:
     iam_resources:
     - type: google.pubsub.v1.Subscription
@@ -233,7 +241,7 @@ interfaces:
         resources_field: received_messages
     resource_name_treatment: STATIC_TYPES
     retry_codes_name: pull
-    retry_params_name: messaging
+    retry_params_name: streaming_messaging
     field_name_patterns:
       subscription: subscription
     timeout_millis: 60000

--- a/google/pubsub/v1/pubsub_gapic.yaml
+++ b/google/pubsub/v1/pubsub_gapic.yaml
@@ -434,7 +434,7 @@ interfaces:
     max_retry_delay_millis: 60000 # 60 seconds
     initial_rpc_timeout_millis: 12000 # 12 seconds
     rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 12000 # 12 seconds
+    max_rpc_timeout_millis: 30000 # 30 seconds
     total_timeout_millis: 600000 # 10 minutes
   experimental_features:
     iam_resources:


### PR DESCRIPTION
During benchmark testing, @blowmage observed a long retry loop
due to continual timeouts when multiple Publishers are used on
and limited-bandwidth connection. This increases the maximum
timeout to address the specific circumstances under which this
behavior was observed. (See
https://github.com/googleapis/gax-ruby/issues/79)

Further, some gRPC languages kill the stream after the timeout;
this affects StreamingPull, where with current configuration, the
Ruby stream will stay open only 12s. Instead bump this to the
maximum 10 minutes.

Updates https://github.com/googleapis/gax-ruby/issues/79