### PR TITLE
Update batch and PHP settings

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -53,13 +53,11 @@ nodejs:
         - generated/nodejs/bigtable
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-bigtable
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-bigtable-v2
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-bigtable-v2
-        - artifact: grpc
-          dest: generated/php/google-cloud-bigtable-v2/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-bigtable-v2
   git_repos:

--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -18,7 +18,6 @@ common:
       location: git@github.com:googleapis/api-client-staging.git
   gapic_api_yaml:
     - ${GOOGLEAPIS}/google/bigtable/v2/bigtable_gapic.yaml
-  enable_batch_generation: False
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-bigtable
 go:

--- a/gapic/api/artman_bigtable_admin.yaml
+++ b/gapic/api/artman_bigtable_admin.yaml
@@ -53,13 +53,11 @@ nodejs:
         - generated/nodejs/bigtable-admin
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-bigtable-admin
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-bigtable-admin-v2
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-bigtable-admin-v2
-        - artifact: grpc
-          dest: generated/php/google-cloud-bigtable-admin-v2/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-bigtable-admin-v2
   git_repos:

--- a/gapic/api/artman_bigtable_admin.yaml
+++ b/gapic/api/artman_bigtable_admin.yaml
@@ -18,7 +18,6 @@ common:
       location: git@github.com:googleapis/api-client-staging.git
   gapic_api_yaml:
     - ${GOOGLEAPIS}/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
-  enable_batch_generation: False
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-bigtable-admin
 go:

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -19,11 +19,9 @@ common:
     staging:
       location: git@github.com:googleapis/api-client-staging.git
   output_dir: ${REPOROOT}/artman/output
-  enable_batch_generation: False
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-debugger
 go:
-  enable_batch_generation: True
   gapic_code_dir: ${REPOROOT}/gapi-cloud-debugger-go
   git_repos:
     go:

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -54,13 +54,11 @@ nodejs:
         - generated/nodejs/debugger
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-debugger
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-debugger-v2
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-debugger-v2
-        - artifact: grpc
-          dest: generated/php/google-cloud-debugger-v2/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-debugger-v2
   git_repos:

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -18,7 +18,6 @@ common:
       location: git@github.com:googleapis/api-client-staging.git
   gapic_api_yaml:
     - ${GOOGLEAPIS}/google/datastore/v1/datastore_gapic.yaml
-  enable_batch_generation: False
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-datastore
 go:

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -53,13 +53,11 @@ nodejs:
         - generated/nodejs/datastore
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-datastore
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-datastore-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-datastore-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-datastore-v1/proto
 python:
   release_level: beta
   generated_package_version:

--- a/gapic/api/artman_dlp.yaml
+++ b/gapic/api/artman_dlp.yaml
@@ -18,7 +18,6 @@ common:
   git_repos:
     staging:
       location: git@github.com:googleapis/api-client-staging.git
-  enable_batch_generation: True
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-dlp
   git_repos:
@@ -80,7 +79,6 @@ ruby:
   generated_package_version:
     lower: 0.20.0
 go:
-  enable_batch_generation: True
   gapic_code_dir: ${REPOROOT}/gapi-cloud-dlp
   git_repos:
     go:

--- a/gapic/api/artman_dlp.yaml
+++ b/gapic/api/artman_dlp.yaml
@@ -89,10 +89,8 @@ go:
       paths:
         - dest: generated/go/vendor/cloud.google.com/go/google-cloud-dlp-v2beta1/vendor
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-dlp
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-dlp-v2beta1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-dlp-v2beta1
-        - artifact: grpc
-          dest: generated/php/google-cloud-dlp-v2beta1/proto

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -57,13 +57,11 @@ nodejs:
         - generated/nodejs/errorreporting
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-error-reporting
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-error-reporting-v1beta1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-error-reporting-v1beta1
-        - artifact: grpc
-          dest: generated/php/google-cloud-error-reporting-v1beta1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-error-reporting-v1beta1
   git_repos:

--- a/gapic/api/artman_functions.yaml
+++ b/gapic/api/artman_functions.yaml
@@ -53,13 +53,11 @@ nodejs:
         - generated/nodejs/functions
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-functions
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-functions-v1beta2
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-functions-v1beta2
-        - artifact: grpc
-          dest: generated/php/google-cloud-functions-v1beta2/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-functions-v1beta2
   git_repos:

--- a/gapic/api/artman_functions.yaml
+++ b/gapic/api/artman_functions.yaml
@@ -18,7 +18,6 @@ common:
   git_repos:
     staging:
       location: git@github.com:googleapis/api-client-staging.git
-  enable_batch_generation: False
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-functions
 go:

--- a/gapic/api/artman_genomics.yaml
+++ b/gapic/api/artman_genomics.yaml
@@ -12,4 +12,3 @@ common:
   src_proto_path:
     - ${GOOGLEAPIS}/google/genomics/v1
   output_dir: ${REPOROOT}/artman/output
-  enable_batch_generation: False

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -39,13 +39,11 @@ go:
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-iam
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-iam
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-iam-admin-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-iam-admin-v1
-        - artifact: grpc
-          dest: generated/php/google-iam-admin-v1/proto
 ruby:
   gapic_code_dir: ${REPOROOT}/google-cloud-ruby/google-cloud-iam
 nodejs:

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -18,7 +18,6 @@ common:
   git_repos:
     staging:
       location: git@github.com:googleapis/api-client-staging.git
-  enable_batch_generation: False
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-iam
   git_repos:
@@ -28,7 +27,6 @@ java:
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gcloud-python-iam
 go:
-  enable_batch_generation: True
   gapic_code_dir: ${REPOROOT}/gapi-cloud-language-go
   git_repos:
     go:

--- a/gapic/api/artman_language_v1.yaml
+++ b/gapic/api/artman_language_v1.yaml
@@ -60,13 +60,11 @@ nodejs:
   generated_package_version:
     lower: 0.11.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-language-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-language-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-language-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-language-v1
   git_repos:

--- a/gapic/api/artman_language_v1beta2.yaml
+++ b/gapic/api/artman_language_v1beta2.yaml
@@ -60,13 +60,11 @@ nodejs:
   generated_package_version:
     lower: 0.11.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-language
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-language-v1beta2
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-language-v1beta2
-        - artifact: grpc
-          dest: generated/php/google-cloud-language-v1beta2/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-language-v1beta2
   git_repos:

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -58,13 +58,11 @@ nodejs:
         - generated/nodejs/logging
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-logging
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-logging-v2
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-logging-v2
-        - artifact: grpc
-          dest: generated/php/google-cloud-logging-v2/proto
 python:
   release_level: beta
   generated_package_version:

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -60,13 +60,11 @@ nodejs:
   generated_package_version:
     lower: 0.3.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-monitoring
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-monitoring-v3
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-monitoring-v3
-        - artifact: grpc
-          dest: generated/php/google-cloud-monitoring-v3/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-monitoring-v3
   git_repos:

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -62,13 +62,11 @@ nodejs:
         - generated/nodejs/pubsub
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-pubsub
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-pubsub-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-pubsub-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-pubsub-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-pubsub-v1
   git_repos:

--- a/gapic/api/artman_spanner.yaml
+++ b/gapic/api/artman_spanner.yaml
@@ -21,7 +21,6 @@ common:
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-spanner
 go:
-  enable_batch_generation: False
   gapic_code_dir: ${REPOROOT}/gapi-cloud-spanner-go
   git_repos:
     go:

--- a/gapic/api/artman_spanner.yaml
+++ b/gapic/api/artman_spanner.yaml
@@ -57,13 +57,11 @@ nodejs:
         - generated/nodejs/spanner
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-spanner
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-spanner-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-spanner-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-spanner-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-spanner-v1
   git_repos:

--- a/gapic/api/artman_spanner_admin_database.yaml
+++ b/gapic/api/artman_spanner_admin_database.yaml
@@ -55,13 +55,11 @@ nodejs:
         - generated/nodejs/spanner-admin-database
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-spanner-admin-database
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-spanner-admin-database-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-spanner-admin-database-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-spanner-admin-database-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-spanner-admin-database-v1
   git_repos:

--- a/gapic/api/artman_spanner_admin_instance.yaml
+++ b/gapic/api/artman_spanner_admin_instance.yaml
@@ -55,13 +55,11 @@ nodejs:
         - generated/nodejs/spanner-admin-instance
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-spanner-admin-instance
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-spanner-admin-instance-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-spanner-admin-instance-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-spanner-admin-instance-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-spanner-admin-instance-v1
   git_repos:

--- a/gapic/api/artman_speech_v1.yaml
+++ b/gapic/api/artman_speech_v1.yaml
@@ -60,13 +60,11 @@ nodejs:
   generated_package_version:
     lower: 0.10.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-speech-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-speech-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-speech-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-speech-v1
   git_repos:

--- a/gapic/api/artman_speech_v1beta1.yaml
+++ b/gapic/api/artman_speech_v1beta1.yaml
@@ -50,13 +50,11 @@ nodejs:
   generated_package_version:
     lower: 0.10.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-speech
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-speech-v1beta1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-speech-v1beta1
-        - artifact: grpc
-          dest: generated/php/google-cloud-speech-v1beta1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-speech-v1beta1
   git_repos:

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -56,13 +56,11 @@ nodejs:
         - generated/nodejs/trace
   skip_packman: True
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-trace
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-trace-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-trace-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-trace-v1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-trace-v1
   git_repos:

--- a/gapic/api/artman_videointelligence.yaml
+++ b/gapic/api/artman_videointelligence.yaml
@@ -21,7 +21,6 @@ common:
 csharp:
   gapic_code_dir: ${REPOROOT}/artman/output/csharp/google-cloud-video-intelligence
 go:
-  enable_batch_generation: True
   gapic_code_dir: ${REPOROOT}/gapi-cloud-video-intelligence-go
   git_repos:
     go:
@@ -70,7 +69,6 @@ php:
         - generated/php/google-cloud-video-intelligence-v1beta1
         - artifact: grpc
           dest: generated/php/google-cloud-video-intelligence-v1beta1/proto
-  enable_batch_generation: True
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-video-intelligence-v1beta1
   git_repos:

--- a/gapic/api/artman_videointelligence.yaml
+++ b/gapic/api/artman_videointelligence.yaml
@@ -62,13 +62,11 @@ nodejs:
   generated_package_version:
     lower: 0.1.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-video-intelligence
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-video-intelligence-v1beta1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-video-intelligence-v1beta1
-        - artifact: grpc
-          dest: generated/php/google-cloud-video-intelligence-v1beta1/proto
 python:
   gapic_code_dir: ${REPOROOT}/artman/output/gapic-google-cloud-video-intelligence-v1beta1
   git_repos:

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -62,13 +62,11 @@ nodejs:
   generated_package_version:
     lower: 0.12.0
 php:
-  gapic_code_dir: ${REPOROOT}/artman/output/gcloud-php-cloud-vision
+  gapic_code_dir: ${REPOROOT}/artman/output/php/google-cloud-vision-v1
   git_repos:
     staging:
       paths:
         - generated/php/google-cloud-vision-v1
-        - artifact: grpc
-          dest: generated/php/google-cloud-vision-v1/proto
 python:
   release_level: beta
   generated_package_version:

--- a/gapic/batch/common.yaml
+++ b/gapic/batch/common.yaml
@@ -4,3 +4,21 @@ common:
     - ${GOOGLEAPIS}/gapic/api/artman_${API_SHORT_NAME}.yaml
     - ${GOOGLEAPIS}/gapic/core/artman_${API_SHORT_NAME}.yaml
   artman_language_yaml: ${GOOGLEAPIS}/gapic/lang/common.yaml
+  exclude_apis:
+    - ${GOOGLEAPIS}/gapic/api/artman_bigtable.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_bigtable_admin.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_clouddebugger.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_datastore.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_functions.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_genomics.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_iam.yaml
+go:
+  exclude_apis:
+    - ${GOOGLEAPIS}/gapic/core/artman_core.yaml
+    - ${GOOGLEAPIS}/gapic/core/artman_iam.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_bigtable.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_bigtable_admin.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_datastore.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_functions.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_genomics.yaml
+    - ${GOOGLEAPIS}/gapic/api/artman_spanner.yaml

--- a/gapic/core/artman_core.yaml
+++ b/gapic/core/artman_core.yaml
@@ -37,5 +37,3 @@ php:
       paths:
         - artifact: grpc
           dest: generated/php/proto-google-common-protos
-go:
-  enable_batch_generation: false

--- a/gapic/core/artman_iam.yaml
+++ b/gapic/core/artman_iam.yaml
@@ -31,5 +31,3 @@ php:
       paths:
         - artifact: grpc
           dest: generated/php/proto-google-iam-v1
-go:
-  enable_batch_generation: false


### PR DESCRIPTION
Corresponding artman PR: https://github.com/googleapis/artman/pull/249

This PR:
- Removes the enable_batch_generation flag from artman config
- Adds an exclude_apis list in the batch config
- Removes the unneeded PHP gRPC publish task, now that artman produces only a single package

@pongad I believe I have correctly configured the batch config so that the behaviour for Go generation will be unchanged - please let me know if this is not the case.