### PR TITLE
Ruby: Refactor the staging output path and add iam staging path

### DIFF
--- a/gapic/api/artman_bigtable.yaml
+++ b/gapic/api/artman_bigtable.yaml
@@ -86,5 +86,5 @@ ruby:
           dest: google-cloud-bigtable/lib/google/cloud/bigtable/v2
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-bigtable
+        - generated/ruby/google-cloud-bigtable
   skip_packman: True

--- a/gapic/api/artman_bigtable_admin.yaml
+++ b/gapic/api/artman_bigtable_admin.yaml
@@ -76,5 +76,5 @@ ruby:
           dest: google-cloud-bigtable-admin/lib/google/cloud/bigtable-admin/v2
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-bigtable-admin
+        - generated/ruby/google-cloud-bigtable-admin
   skip_packman: True

--- a/gapic/api/artman_clouddebugger.yaml
+++ b/gapic/api/artman_clouddebugger.yaml
@@ -77,5 +77,5 @@ ruby:
           dest: google-cloud-debugger/lib/google/cloud/debugger/v2
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-debugger
+        - generated/ruby/google-cloud-debugger
   skip_packman: True

--- a/gapic/api/artman_datastore.yaml
+++ b/gapic/api/artman_datastore.yaml
@@ -90,5 +90,5 @@ ruby:
           dest: google-cloud-datastore/lib/google/cloud/datastore/v1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-datastore
+        - generated/ruby/google-cloud-datastore
   skip_packman: True

--- a/gapic/api/artman_dlp.yaml
+++ b/gapic/api/artman_dlp.yaml
@@ -75,7 +75,7 @@ ruby:
       location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-dlp
+        - generated/ruby/google-cloud-dlp
   generated_package_version:
     lower: 0.20.0
 go:

--- a/gapic/api/artman_errorreporting.yaml
+++ b/gapic/api/artman_errorreporting.yaml
@@ -90,5 +90,5 @@ ruby:
           dest: google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-error_reporting
+        - generated/ruby/google-cloud-error_reporting
   skip_packman: True

--- a/gapic/api/artman_functions.yaml
+++ b/gapic/api/artman_functions.yaml
@@ -76,5 +76,5 @@ ruby:
           dest: google-cloud-functions/lib/google/cloud/functions/v1beta2
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-functions
+        - generated/ruby/google-cloud-functions
   skip_packman: True

--- a/gapic/api/artman_iam.yaml
+++ b/gapic/api/artman_iam.yaml
@@ -46,6 +46,10 @@ php:
         - generated/php/google-iam-admin-v1
 ruby:
   gapic_code_dir: ${REPOROOT}/artman/output/ruby/google-cloud-ruby/google-cloud-iam
+  git_repos:
+    staging:
+      paths:
+        - generated/ruby/google-cloud-iam
 nodejs:
   gapic_code_dir: ${REPOROOT}/artman/output/js/iam-v1
   git_repos:

--- a/gapic/api/artman_language_v1.yaml
+++ b/gapic/api/artman_language_v1.yaml
@@ -93,5 +93,5 @@ ruby:
           dest: google-cloud-language/lib/google/cloud/language/v1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-language
+        - generated/ruby/google-cloud-language
   skip_packman: True

--- a/gapic/api/artman_language_v1beta2.yaml
+++ b/gapic/api/artman_language_v1beta2.yaml
@@ -93,5 +93,5 @@ ruby:
           dest: google-cloud-language/lib/google/cloud/language/v1beta2
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-language-v1beta2
+        - generated/ruby/google-cloud-language-v1beta2
   skip_packman: True

--- a/gapic/api/artman_logging.yaml
+++ b/gapic/api/artman_logging.yaml
@@ -95,5 +95,5 @@ ruby:
           dest: google-cloud-logging/lib/google/cloud/logging/v2
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-logging
+        - generated/ruby/google-cloud-logging
   skip_packman: True

--- a/gapic/api/artman_longrunning.yaml
+++ b/gapic/api/artman_longrunning.yaml
@@ -84,4 +84,4 @@ ruby:
           dest: lib/google/longrunning
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-longrunning
+        - generated/ruby/google-cloud-longrunning

--- a/gapic/api/artman_monitoring.yaml
+++ b/gapic/api/artman_monitoring.yaml
@@ -93,5 +93,5 @@ ruby:
           dest: google-cloud-monitoring/lib/google/cloud/monitoring/v3
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-monitoring
+        - generated/ruby/google-cloud-monitoring
   skip_packman: True

--- a/gapic/api/artman_pubsub.yaml
+++ b/gapic/api/artman_pubsub.yaml
@@ -95,5 +95,5 @@ ruby:
       location: git@github.com:GoogleCloudPlatform/google-cloud-ruby.git
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-pubsub
+        - generated/ruby/google-cloud-pubsub
   skip_packman: True

--- a/gapic/api/artman_spanner.yaml
+++ b/gapic/api/artman_spanner.yaml
@@ -90,5 +90,5 @@ ruby:
           dest: google-cloud-spanner/lib/google/cloud/spanner/v1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-spanner
+        - generated/ruby/google-cloud-spanner
   skip_packman: True

--- a/gapic/api/artman_spanner_admin_database.yaml
+++ b/gapic/api/artman_spanner_admin_database.yaml
@@ -78,5 +78,5 @@ ruby:
           dest: google-cloud-spanner/lib/google/cloud/spanner/admin/database
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-spanner-admin-database
+        - generated/ruby/google-cloud-spanner-admin-database
   skip_packman: True

--- a/gapic/api/artman_spanner_admin_instance.yaml
+++ b/gapic/api/artman_spanner_admin_instance.yaml
@@ -78,5 +78,5 @@ ruby:
           dest: google-cloud-spanner/lib/google/cloud/spanner/admin/instance
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-spanner-admin-instance
+        - generated/ruby/google-cloud-spanner-admin-instance
   skip_packman: True

--- a/gapic/api/artman_speech_v1.yaml
+++ b/gapic/api/artman_speech_v1.yaml
@@ -93,5 +93,5 @@ ruby:
           dest: google-cloud-speech/lib/google/cloud/speech/v1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-speech-v1
+        - generated/ruby/google-cloud-speech-v1
   skip_packman: True

--- a/gapic/api/artman_speech_v1beta1.yaml
+++ b/gapic/api/artman_speech_v1beta1.yaml
@@ -78,5 +78,5 @@ ruby:
   git_repos:
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-speech-v1beta1
+        - generated/ruby/google-cloud-speech-v1beta1
   skip_packman: True

--- a/gapic/api/artman_trace.yaml
+++ b/gapic/api/artman_trace.yaml
@@ -89,5 +89,5 @@ ruby:
           dest: google-cloud-trace/lib/google/cloud/trace/v1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-trace
+        - generated/ruby/google-cloud-trace
   skip_packman: True

--- a/gapic/api/artman_videointelligence.yaml
+++ b/gapic/api/artman_videointelligence.yaml
@@ -95,5 +95,5 @@ ruby:
           dest: google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1
     staging:
       paths:
-        - dest: generated/ruby/google-cloud-ruby/google-cloud-video_intelligence
+        - dest: generated/ruby/google-cloud-video_intelligence
   skip_packman: True

--- a/gapic/api/artman_vision.yaml
+++ b/gapic/api/artman_vision.yaml
@@ -99,5 +99,5 @@ ruby:
           dest: google-cloud-vision/lib/google/cloud/vision/v1
     staging:
       paths:
-        - generated/ruby/google-cloud-ruby/google-cloud-vision
+        - generated/ruby/google-cloud-vision
   skip_packman: True

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -47,7 +47,7 @@ gax_version:
   php:
     lower: '0.20.0'
   ruby:
-    lower: '0.8.5'
+    lower: '0.8.6'
   java:
     lower: '1.5.0'
 


### PR DESCRIPTION
The directory `google-cloud-ruby` in api-client-staging is not necessary.