### PR TITLE
spanner: enable batch in go

### DIFF
--- a/gapic/api/artman_spanner.yaml
+++ b/gapic/api/artman_spanner.yaml
@@ -29,7 +29,7 @@ go:
         - spanner/apiv1
     staging:
       paths:
-        - generated/go/vendor/cloud.google.com/go/google-spanner-admin-v1/vendor
+        - generated/go/vendor/cloud.google.com/go/google-spanner-v1/vendor
 java:
   gapic_code_dir: ${REPOROOT}/artman/output/java/google-cloud-spanner
   git_repos:

--- a/gapic/batch/common.yaml
+++ b/gapic/batch/common.yaml
@@ -21,4 +21,3 @@ go:
     - ${GOOGLEAPIS}/gapic/api/artman_datastore.yaml
     - ${GOOGLEAPIS}/gapic/api/artman_functions.yaml
     - ${GOOGLEAPIS}/gapic/api/artman_genomics.yaml
-    - ${GOOGLEAPIS}/gapic/api/artman_spanner.yaml


### PR DESCRIPTION
Previously Go's handwritten client uses the raw grpc client.
We're migrating the handwritten client to use GAPIC.