### PR TITLE
Bigtable admin gapic config

### DIFF
--- a/google/bigtable/admin/bigtableadmin.yaml
+++ b/google/bigtable/admin/bigtableadmin.yaml
@@ -1,5 +1,3 @@
-# Google Bigtable Admin API service configuration
-
 type: google.api.Service
 config_version: 3
 name: bigtableadmin.googleapis.com
@@ -8,69 +6,80 @@ title: Cloud Bigtable Admin API
 apis:
 - name: google.bigtable.admin.v2.BigtableInstanceAdmin
 - name: google.bigtable.admin.v2.BigtableTableAdmin
-- name: google.longrunning.Operations
 
-# Additional types which are used as google.protobuf.Any values
 types:
 - name: google.bigtable.admin.v2.CreateInstanceMetadata
+- name: google.bigtable.admin.v2.CreateClusterMetadata
 - name: google.bigtable.admin.v2.UpdateClusterMetadata
+
+http:
+  rules:
+  - selector: google.longrunning.Operations.ListOperations
+    get: '/v2/{name=operations}'
+
+  - selector: google.longrunning.Operations.GetOperation
+    get: '/v2/{name=operations/**}'
+
+  - selector: google.longrunning.Operations.DeleteOperation
+    delete: '/v2/{name=operations/**}'
+
+  - selector: google.longrunning.Operations.CancelOperation
+    post: '/v2/{name=operations/**}:cancel'
+
 
 authentication:
   rules:
-    # Unless explicitly weakened, all BigtableInstanceAdmin ops require cluster
-    # admin access.
-    - selector: google.bigtable.admin.v2.BigtableInstanceAdmin.*,
-                google.longrunning.Operations.*
-      oauth:
-        canonical_scopes: https://www.googleapis.com/auth/bigtable.admin,
-                          https://www.googleapis.com/auth/bigtable.admin.cluster,
-                          https://www.googleapis.com/auth/bigtable.admin.instance,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin.cluster,
-                          https://www.googleapis.com/auth/cloud-platform
-    # BigtableInstanceAdmin Ops which only require read access
-    - selector: google.bigtable.admin.v2.BigtableInstanceAdmin.GetCluster,
-                google.bigtable.admin.v2.BigtableInstanceAdmin.GetInstance,
-                google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters,
-                google.bigtable.admin.v2.BigtableInstanceAdmin.ListInstances,
-                google.longrunning.Operations.GetOperation,
-                google.longrunning.Operations.ListOperations
-      oauth:
-        canonical_scopes: https://www.googleapis.com/auth/bigtable.admin,
-                          https://www.googleapis.com/auth/bigtable.admin.cluster,
-                          https://www.googleapis.com/auth/bigtable.admin.instance,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin.cluster,
-                          https://www.googleapis.com/auth/cloud-platform,
-                          https://www.googleapis.com/auth/cloud-platform.read-only
-
-    # Unless explicitly weakened, all BigtableTableAdmin ops require table admin access
-    - selector: google.bigtable.admin.v2.BigtableTableAdmin.*
-      oauth:
-        canonical_scopes: https://www.googleapis.com/auth/bigtable.admin,
-                          https://www.googleapis.com/auth/bigtable.admin.table,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin.table,
-                          https://www.googleapis.com/auth/cloud-platform
-    # BigtableTableAdmin Ops which only require read access
-    - selector: google.bigtable.admin.v2.BigtableTableAdmin.GetTable,
-                google.bigtable.admin.v2.BigtableTableAdmin.ListTables
-      oauth:
-        canonical_scopes: https://www.googleapis.com/auth/bigtable.admin,
-                          https://www.googleapis.com/auth/bigtable.admin.table,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin,
-                          https://www.googleapis.com/auth/cloud-bigtable.admin.table,
-                          https://www.googleapis.com/auth/cloud-platform,
-                          https://www.googleapis.com/auth/cloud-platform.read-only
-
-# Http override to expose Operations API at v2
-http:
-  rules:
-  - selector: google.longrunning.Operations.GetOperation
-    get: '/v2/{name=operations/**}'
-  - selector: google.longrunning.Operations.ListOperations
-    get: '/v2/{name=operations}'
-  - selector: google.longrunning.Operations.CancelOperation
-    post: '/v2/{name=operations/**}:cancel'
-  - selector: google.longrunning.Operations.DeleteOperation
-    delete: '/v2/{name=operations/**}'
+  - selector: '*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/bigtable.admin,
+        https://www.googleapis.com/auth/bigtable.admin.cluster,
+        https://www.googleapis.com/auth/bigtable.admin.instance,
+        https://www.googleapis.com/auth/cloud-bigtable.admin,
+        https://www.googleapis.com/auth/cloud-bigtable.admin.cluster,
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: 'google.bigtable.admin.v2.BigtableTableAdmin.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/bigtable.admin,
+        https://www.googleapis.com/auth/bigtable.admin.table,
+        https://www.googleapis.com/auth/cloud-bigtable.admin,
+        https://www.googleapis.com/auth/cloud-bigtable.admin.table,
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: |-
+      google.bigtable.admin.v2.BigtableInstanceAdmin.GetCluster,
+      google.bigtable.admin.v2.BigtableInstanceAdmin.GetInstance,
+      google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters,
+      google.bigtable.admin.v2.BigtableInstanceAdmin.ListInstances
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/bigtable.admin,
+        https://www.googleapis.com/auth/bigtable.admin.cluster,
+        https://www.googleapis.com/auth/bigtable.admin.instance,
+        https://www.googleapis.com/auth/cloud-bigtable.admin,
+        https://www.googleapis.com/auth/cloud-bigtable.admin.cluster,
+        https://www.googleapis.com/auth/cloud-platform,
+        https://www.googleapis.com/auth/cloud-platform.read-only
+  - selector: |-
+      google.bigtable.admin.v2.BigtableTableAdmin.GetTable,
+      google.bigtable.admin.v2.BigtableTableAdmin.ListTables
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/bigtable.admin,
+        https://www.googleapis.com/auth/bigtable.admin.table,
+        https://www.googleapis.com/auth/cloud-bigtable.admin,
+        https://www.googleapis.com/auth/cloud-bigtable.admin.table,
+        https://www.googleapis.com/auth/cloud-platform,
+        https://www.googleapis.com/auth/cloud-platform.read-only
+  - selector: |-
+      google.longrunning.Operations.GetOperation,
+      google.longrunning.Operations.ListOperations
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/bigtable.admin,
+        https://www.googleapis.com/auth/bigtable.admin.cluster,
+        https://www.googleapis.com/auth/bigtable.admin.instance,
+        https://www.googleapis.com/auth/cloud-bigtable.admin,
+        https://www.googleapis.com/auth/cloud-bigtable.admin.cluster,
+        https://www.googleapis.com/auth/cloud-platform,
+        https://www.googleapis.com/auth/cloud-platform.read-only

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -61,6 +61,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: project
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: GetInstance
     flattening:
@@ -70,6 +71,7 @@ interfaces:
     required_fields:
     - name
     request_object_method: false
+    resource_name_treatment: STATIC_TYPES
     retry_codes_name: idempotent
     retry_params_name: default
     field_name_patterns:
@@ -87,6 +89,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: project
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: UpdateInstance
     flattening:
@@ -106,6 +109,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: instance
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: DeleteInstance
     flattening:
@@ -119,6 +123,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: instance
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: CreateCluster
     flattening:
@@ -136,6 +141,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: instance
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: GetCluster
     flattening:
@@ -149,6 +155,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: cluster
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: ListClusters
     flattening:
@@ -162,6 +169,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: instance
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: UpdateCluster
     required_fields:
@@ -175,6 +183,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: cluster
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: DeleteCluster
     flattening:
@@ -188,6 +197,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: cluster
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
 - name: google.bigtable.admin.v2.BigtableTableAdmin
   collections:
@@ -230,6 +240,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: instance
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: ListTables
     flattening:
@@ -251,6 +262,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: instance
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: GetTable
     flattening:
@@ -266,6 +278,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: table
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: DeleteTable
     flattening:
@@ -279,6 +292,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: table
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: ModifyColumnFamilies
     flattening:
@@ -294,6 +308,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: table
+    resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: DropRowRange
     flattening:
@@ -311,7 +326,9 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: table
+      resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
+
 - name: google.longrunning.Operations
   collections:
   - name_pattern: operations/{operation_path=**}
@@ -392,3 +409,62 @@ interfaces:
     field_name_patterns:
       name: operation_path
     timeout_millis: 60000
+
+resource_name_generation:
+- message_name: CreateInstanceRequest
+  field_entity_map:
+    parent: project
+- message_name: GetInstanceRequest
+  field_entity_map:
+    name: instance
+- message_name: ListInstancesRequest
+  field_entity_map:
+    parent: project
+- message_name: UpdateInstanceRequest
+  field_entity_map:
+    name: instance
+- message_name: DeleteInstanceRequest
+  field_entity_map:
+    name: instance
+- message_name: CreateClusterRequest
+  field_entity_map:
+    parent: instance
+- message_name: GetClusterRequest
+  field_entity_map:
+    name: cluster
+- message_name: ListClustersRequest
+  field_entity_map:
+    parent: instance
+- message_name: UpdateClusterRequest
+  field_entity_map:
+    name: cluster
+- message_name: DeleteClusterRequest
+  field_entity_map:
+    name: cluster
+- message_name: CreateTableRequest
+  field_entity_map:
+    parent: instance
+- message_name: ListTablesRequest
+  field_entity_map:
+    parent: instance
+- message_name: GetTableRequest
+  field_entity_map:
+    name: table
+- message_name: DeleteTableRequest
+  field_entity_map:
+    name: table
+- message_name: ModifyColumnFamiliesRequest
+  field_entity_map:
+    name: table
+- message_name: DropRowRangeRequest
+  field_entity_map:
+    name: table
+- message_name: Instance
+  field_entity_map:
+    name: instance
+- message_name: Cluster
+  field_entity_map:
+    name: cluster
+- message_name: Table
+  field_entity_map:
+    name: table

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -32,15 +32,16 @@ interfaces:
     - UNAVAILABLE
     - DEADLINE_EXCEEDED
   - name: non_idempotent
-    retry_codes: []
+    retry_codes:
+    - UNAVAILABLE
   retry_params_def:
   - name: default
-    initial_retry_delay_millis: 100
-    retry_delay_multiplier: 1.3
+    initial_retry_delay_millis: 5
+    retry_delay_multiplier: 2
     max_retry_delay_millis: 60000
-    initial_rpc_timeout_millis: 20000
+    initial_rpc_timeout_millis: 60000
     rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 20000
+    max_rpc_timeout_millis: 60000
     total_timeout_millis: 600000
   methods:
   - name: CreateInstance

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -97,12 +97,10 @@ interfaces:
       - parameters:
         - name
         - display_name
-        - state
         - type
     required_fields:
     - name
     - display_name
-    - state
     - type
     request_object_method: true
     retry_codes_name: idempotent
@@ -172,10 +170,16 @@ interfaces:
     resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
   - name: UpdateCluster
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - location
+        - serve_nodes
+        - default_storage_type
     required_fields:
     - name
     - location
-    - state
     - serve_nodes
     - default_storage_type
     request_object_method: true
@@ -229,12 +233,10 @@ interfaces:
         - parent
         - table_id
         - table
-        - initial_splits
     required_fields:
     - parent
     - table_id
     - table
-    - initial_splits
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -247,11 +249,9 @@ interfaces:
       groups:
       - parameters:
         - parent
-        - view
     required_fields:
     - parent
-    - view
-    request_object_method: true
+    request_object_method: false
     page_streaming:
       request:
         token_field: page_token
@@ -269,10 +269,8 @@ interfaces:
       groups:
       - parameters:
         - name
-        - view
     required_fields:
     - name
-    - view
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
@@ -316,11 +314,8 @@ interfaces:
       - parameters:
         - name
         - row_key_prefix
-        - delete_all_data_from_table
     required_fields:
     - name
-    - row_key_prefix
-    - delete_all_data_from_table
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -468,3 +463,4 @@ resource_name_generation:
 - message_name: Table
   field_entity_map:
     name: table
+

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -1,0 +1,394 @@
+type: com.google.api.codegen.ConfigProto
+language_settings:
+  java:
+    package_name: com.google.cloud.bigtable.admin.spi.v2
+  python:
+    package_name: google.cloud.gapic.bigtable.admin.v2
+  go:
+    package_name: cloud.google.com/go/bigtable/admin/apiv2
+  csharp:
+    package_name: Google.Bigtable.Admin.V2
+  ruby:
+    package_name: Google::Cloud::Bigtable::Admin::V2
+  php:
+    package_name: Google\Cloud\Bigtable\Admin\V2
+  nodejs:
+    package_name: admin.v2
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
+interfaces:
+- name: google.bigtable.admin.v2.BigtableInstanceAdmin
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/instances/{instance}
+    entity_name: instance
+  - name_pattern: projects/{project}/instances/{instance}/clusters/{cluster}
+    entity_name: cluster
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  methods:
+  - name: CreateInstance
+    flattening:
+      groups:
+      - parameters:
+        - parent
+        - instance_id
+        - instance
+        - clusters
+    required_fields:
+    - parent
+    - instance_id
+    - instance
+    - clusters
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      parent: project
+    timeout_millis: 60000
+  - name: GetInstance
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: instance
+    timeout_millis: 60000
+  - name: ListInstances
+    flattening:
+      groups:
+      - parameters:
+        - parent
+    required_fields:
+    - parent
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      parent: project
+    timeout_millis: 60000
+  - name: UpdateInstance
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - display_name
+        - state
+        - type
+    required_fields:
+    - name
+    - display_name
+    - state
+    - type
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: instance
+    timeout_millis: 60000
+  - name: DeleteInstance
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: instance
+    timeout_millis: 60000
+  - name: CreateCluster
+    flattening:
+      groups:
+      - parameters:
+        - parent
+        - cluster_id
+        - cluster
+    required_fields:
+    - parent
+    - cluster_id
+    - cluster
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      parent: instance
+    timeout_millis: 60000
+  - name: GetCluster
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: cluster
+    timeout_millis: 60000
+  - name: ListClusters
+    flattening:
+      groups:
+      - parameters:
+        - parent
+    required_fields:
+    - parent
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      parent: instance
+    timeout_millis: 60000
+  - name: UpdateCluster
+    required_fields:
+    - name
+    - location
+    - state
+    - serve_nodes
+    - default_storage_type
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: cluster
+    timeout_millis: 60000
+  - name: DeleteCluster
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: cluster
+    timeout_millis: 60000
+- name: google.bigtable.admin.v2.BigtableTableAdmin
+  collections:
+  - name_pattern: projects/{project}/instances/{instance}
+    entity_name: instance
+  - name_pattern: projects/{project}/instances/{instance}/tables/{table}
+    entity_name: table
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  methods:
+  - name: CreateTable
+    flattening:
+      groups:
+      - parameters:
+        - parent
+        - table_id
+        - table
+        - initial_splits
+    required_fields:
+    - parent
+    - table_id
+    - table
+    - initial_splits
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      parent: instance
+    timeout_millis: 60000
+  - name: ListTables
+    flattening:
+      groups:
+      - parameters:
+        - parent
+        - view
+    required_fields:
+    - parent
+    - view
+    request_object_method: true
+    page_streaming:
+      request:
+        token_field: page_token
+      response:
+        token_field: next_page_token
+        resources_field: tables
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      parent: instance
+    timeout_millis: 60000
+  - name: GetTable
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - view
+    required_fields:
+    - name
+    - view
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: table
+    timeout_millis: 60000
+  - name: DeleteTable
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: table
+    timeout_millis: 60000
+  - name: ModifyColumnFamilies
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - modifications
+    required_fields:
+    - name
+    - modifications
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: table
+    timeout_millis: 60000
+  - name: DropRowRange
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - row_key_prefix
+        - delete_all_data_from_table
+    required_fields:
+    - name
+    - row_key_prefix
+    - delete_all_data_from_table
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: table
+    timeout_millis: 60000
+- name: google.longrunning.Operations
+  collections:
+  - name_pattern: operations/{operation_path=**}
+    entity_name: operation_path
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  methods:
+  - name: ListOperations
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - filter
+    required_fields:
+    - name
+    - filter
+    request_object_method: true
+    page_streaming:
+      request:
+        page_size_field: page_size
+        token_field: page_token
+      response:
+        token_field: next_page_token
+        resources_field: operations
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 60000
+  - name: GetOperation
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: operation_path
+    timeout_millis: 60000
+  - name: DeleteOperation
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: operation_path
+    timeout_millis: 60000
+  - name: CancelOperation
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: operation_path
+    timeout_millis: 60000

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -150,7 +150,7 @@ interfaces:
     long_running:
       return_type: google.bigtable.admin.v2.Cluster
       metadata_type: google.bigtable.admin.v2.CreateClusterMetadata
-      initial_poll_delay_millis: 1000
+      initial_poll_delay_millis: 500
       poll_delay_multiplier: 1.5
       max_poll_delay_millis: 5000
       total_poll_timeout_millis: 4147200000

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -267,7 +267,7 @@ interfaces:
     field_name_patterns:
       parent: instance
     resource_name_treatment: STATIC_TYPES
-    timeout_millis: 60000
+    timeout_millis: 130000
   - name: ListTables
     flattening:
       groups:

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -149,6 +149,9 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: instance
+    surface_treatments:
+    - visibility: DISABLED
+      include_languages: ["java", "python", "go", "csharp", "ruby", "php", "nodejs"]
     resource_name_treatment: STATIC_TYPES
     long_running:
       return_type: google.bigtable.admin.v2.Cluster

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -154,7 +154,7 @@ interfaces:
       initial_poll_delay_millis: 500
       poll_delay_multiplier: 1.5
       max_poll_delay_millis: 5000
-      total_poll_timeout_millis: 4147200000
+      total_poll_timeout_millis: 300000
     timeout_millis: 60000
   - name: GetCluster
     flattening:

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -63,6 +63,13 @@ interfaces:
       parent: project
     resource_name_treatment: STATIC_TYPES
     timeout_millis: 60000
+    long_running:
+      return_type: google.bigtable.admin.v2.Instance
+      metadata_type: google.bigtable.admin.v2.CreateInstanceMetadata
+      initial_poll_delay_millis: 500
+      poll_delay_multiplier: 1.5
+      max_poll_delay_millis: 5000
+      total_poll_timeout_millis: 300000
   - name: GetInstance
     flattening:
       groups:
@@ -140,6 +147,13 @@ interfaces:
     field_name_patterns:
       parent: instance
     resource_name_treatment: STATIC_TYPES
+    long_running:
+      return_type: google.bigtable.admin.v2.Cluster
+      metadata_type: google.bigtable.admin.v2.CreateClusterMetadata
+      initial_poll_delay_millis: 1000
+      poll_delay_multiplier: 1.5
+      max_poll_delay_millis: 5000
+      total_poll_timeout_millis: 4147200000
     timeout_millis: 60000
   - name: GetCluster
     flattening:
@@ -188,6 +202,13 @@ interfaces:
     field_name_patterns:
       name: cluster
     resource_name_treatment: STATIC_TYPES
+    long_running:
+      return_type: google.bigtable.admin.v2.Cluster
+      metadata_type: google.bigtable.admin.v2.UpdateClusterMetadata
+      initial_poll_delay_millis: 500
+      poll_delay_multiplier: 1.5
+      max_poll_delay_millis: 5000
+      total_poll_timeout_millis: 300000
     timeout_millis: 60000
   - name: DeleteCluster
     flattening:
@@ -322,87 +343,6 @@ interfaces:
     field_name_patterns:
       name: table
       resource_name_treatment: STATIC_TYPES
-    timeout_millis: 60000
-
-- name: google.longrunning.Operations
-  collections:
-  - name_pattern: operations/{operation_path=**}
-    entity_name: operation_path
-  retry_codes_def:
-  - name: idempotent
-    retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
-  - name: non_idempotent
-    retry_codes: []
-  retry_params_def:
-  - name: default
-    initial_retry_delay_millis: 100
-    retry_delay_multiplier: 1.3
-    max_retry_delay_millis: 60000
-    initial_rpc_timeout_millis: 20000
-    rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 20000
-    total_timeout_millis: 600000
-  methods:
-  - name: ListOperations
-    flattening:
-      groups:
-      - parameters:
-        - name
-        - filter
-    required_fields:
-    - name
-    - filter
-    request_object_method: true
-    page_streaming:
-      request:
-        page_size_field: page_size
-        token_field: page_token
-      response:
-        token_field: next_page_token
-        resources_field: operations
-    retry_codes_name: idempotent
-    retry_params_name: default
-    timeout_millis: 60000
-  - name: GetOperation
-    flattening:
-      groups:
-      - parameters:
-        - name
-    required_fields:
-    - name
-    request_object_method: false
-    retry_codes_name: idempotent
-    retry_params_name: default
-    field_name_patterns:
-      name: operation_path
-    timeout_millis: 60000
-  - name: DeleteOperation
-    flattening:
-      groups:
-      - parameters:
-        - name
-    required_fields:
-    - name
-    request_object_method: false
-    retry_codes_name: idempotent
-    retry_params_name: default
-    field_name_patterns:
-      name: operation_path
-    timeout_millis: 60000
-  - name: CancelOperation
-    flattening:
-      groups:
-      - parameters:
-        - name
-    required_fields:
-    - name
-    request_object_method: false
-    retry_codes_name: non_idempotent
-    retry_params_name: default
-    field_name_patterns:
-      name: operation_path
     timeout_millis: 60000
 
 resource_name_generation:

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -26,6 +26,8 @@ interfaces:
     entity_name: instance
   - name_pattern: projects/{project}/instances/{instance}/clusters/{cluster}
     entity_name: cluster
+  - name_pattern: projects/{project}/locations/{location}
+    entity_name: location
   retry_codes_def:
   - name: idempotent
     retry_codes:
@@ -401,6 +403,7 @@ resource_name_generation:
 - message_name: Cluster
   field_entity_map:
     name: cluster
+    location: location
 - message_name: Table
   field_entity_map:
     name: table

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -1,7 +1,7 @@
 type: com.google.api.codegen.ConfigProto
 language_settings:
   java:
-    package_name: com.google.cloud.bigtable.admin.spi.v2
+    package_name: com.google.cloud.bigtable.admin.v2
   python:
     package_name: google.cloud.gapic.bigtable.admin.v2
   go:

--- a/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
+++ b/google/bigtable/admin/v2/bigtable_admin_gapic.yaml
@@ -149,9 +149,6 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       parent: instance
-    surface_treatments:
-    - visibility: DISABLED
-      include_languages: ["java", "python", "go", "csharp", "ruby", "php", "nodejs"]
     resource_name_treatment: STATIC_TYPES
     long_running:
       return_type: google.bigtable.admin.v2.Cluster

--- a/google/bigtable/admin/v2/bigtable_instance_admin.proto
+++ b/google/bigtable/admin/v2/bigtable_instance_admin.proto
@@ -18,8 +18,11 @@ package google.bigtable.admin.v2;
 
 import "google/api/annotations.proto";
 import "google/bigtable/admin/v2/instance.proto";
+import "google/iam/v1/iam_policy.proto";
+import "google/iam/v1/policy.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/bigtable/admin/v2;admin";
@@ -212,6 +215,18 @@ message DeleteClusterRequest {
 message CreateInstanceMetadata {
   // The request that prompted the initiation of this CreateInstance operation.
   CreateInstanceRequest original_request = 1;
+
+  // The time at which the original request was received.
+  google.protobuf.Timestamp request_time = 2;
+
+  // The time at which the operation failed or was completed successfully.
+  google.protobuf.Timestamp finish_time = 3;
+}
+
+// The metadata for the Operation returned by CreateCluster.
+message CreateClusterMetadata {
+  // The request that prompted the initiation of this CreateCluster operation.
+  CreateClusterRequest original_request = 1;
 
   // The time at which the original request was received.
   google.protobuf.Timestamp request_time = 2;

--- a/google/bigtable/admin/v2/bigtable_table_admin.proto
+++ b/google/bigtable/admin/v2/bigtable_table_admin.proto
@@ -57,8 +57,10 @@ service BigtableTableAdmin {
     option (google.api.http) = { delete: "/v2/{name=projects/*/instances/*/tables/*}" };
   }
 
-  // Atomically performs a series of column family modifications
-  // on the specified table.
+  // Performs a series of column family modifications on the specified table.
+  // Either all or none of the modifications will occur before this method
+  // returns, but data requests received prior to that point may see a table
+  // where only some modifications have taken effect.
   rpc ModifyColumnFamilies(ModifyColumnFamiliesRequest) returns (Table) {
     option (google.api.http) = { post: "/v2/{name=projects/*/instances/*/tables/*}:modifyColumnFamilies" body: "*" };
   }


### PR DESCRIPTION
Current outstanding issues:
- ListInstances & ListClusters methods can return incomplete results if a zone is down. The methods also support pagination (which isn't currently implemented on the server side). The semantics of partial pagination is rather hard to express in gapic (and in general). I think the easiest thing would be to insert a callable before the PagedCallable that returns an error anytime a zone is unavailable. 
- Create & Delete Cluster are exposed in this client even though they are disabled on the server.
