### PR TITLE
spanner: Reducing total timeout of rpcs to equal rpc timeout.

### DIFF
--- a/google/spanner/v1/spanner_gapic.yaml
+++ b/google/spanner/v1/spanner_gapic.yaml
@@ -52,7 +52,7 @@ interfaces:
     initial_rpc_timeout_millis: 3600000
     rpc_timeout_multiplier: 1
     max_rpc_timeout_millis: 3600000
-    total_timeout_millis: 36000000
+    total_timeout_millis: 3600000
   methods:
   - name: CreateSession
     flattening:


### PR DESCRIPTION
@garrettjonesgoogle PTAL