### PR TITLE
Add google/appengine/v1/audit_data.proto dependencies.

### DIFF
--- a/gapic/core/artman_appengine.yaml
+++ b/gapic/core/artman_appengine.yaml
@@ -1,22 +1,18 @@
 common:
-  api_name: logging-external-types
-  api_version: ""
+  api_name: appengine
+  api_version: v1
   package_type: grpc_common
   packaging: google-cloud
   organization_name: google
   proto_deps:
     - google-common-protos
     - google-iam-v1
-    - google-appengine-v1
   import_proto_path:
     - ${GOOGLEAPIS}
   src_proto_path:
-    - ${GOOGLEAPIS}/google/appengine/legacy
-    - ${GOOGLEAPIS}/google/appengine/logging/v1
+    - ${GOOGLEAPIS}/google/appengine/v1
+  excluded_proto_path:
     - ${GOOGLEAPIS}/google/appengine/v1/audit_data.proto
-    - ${GOOGLEAPIS}/google/cloud/audit
-    - ${GOOGLEAPIS}/google/cloud/bigquery/logging/v1
-    - ${GOOGLEAPIS}/google/iam/v1/logging
   output_dir: ${REPOROOT}/artman/output
   gapic_api_yaml: []
   service_yaml: []
@@ -28,12 +24,12 @@ java:
     staging:
       paths:
         - artifact: proto
-          dest: generated/java/proto-google-logging-external-types
+          dest: generated/java/proto-google-appengine
         - artifact: grpc
-          dest: generated/java/grpc-google-logging-external-types
+          dest: generated/java/grpc-google-appengine
 php:
   git_repos:
     staging:
       paths:
         - artifact: grpc
-          dest: generated/php/google-logging-external-types
+          dest: generated/php/google-appengine

--- a/gapic/core/artman_logging_external_types.yaml
+++ b/gapic/core/artman_logging_external_types.yaml
@@ -12,7 +12,7 @@ common:
   src_proto_path:
     - ${GOOGLEAPIS}/google/appengine/legacy
     - ${GOOGLEAPIS}/google/appengine/logging/v1
-    - ${GOOGLEAPIS}/google/appengine/v1/audit_data.proto
+    - ${GOOGLEAPIS}/google/appengine/v1
     - ${GOOGLEAPIS}/google/cloud/audit
     - ${GOOGLEAPIS}/google/cloud/bigquery/logging/v1
     - ${GOOGLEAPIS}/google/iam/v1/logging


### PR DESCRIPTION
Following the dependency tree requires the whole google/appengine/v1 folder.