### PR TITLE
go videointelligence: remove domain layer location

### DIFF
--- a/google/cloud/videointelligence/v1beta1/videointelligence_gapic.yaml
+++ b/google/cloud/videointelligence/v1beta1/videointelligence_gapic.yaml
@@ -6,7 +6,6 @@ language_settings:
     package_name: google.cloud.videointelligence_v1beta1.gapic
   go:
     package_name: cloud.google.com/go/videointelligence/apiv1beta1
-    domain_layer_location: cloud.google.com/go/videointelligence
   csharp:
     package_name: Google.Cloud.VideoIntelligence.V1Beta1
   ruby:

--- a/google/cloud/videointelligence/v1beta2/videointelligence_gapic.yaml
+++ b/google/cloud/videointelligence/v1beta2/videointelligence_gapic.yaml
@@ -6,7 +6,6 @@ language_settings:
     package_name: google.cloud.videointelligence_v1beta2.gapic
   go:
     package_name: cloud.google.com/go/videointelligence/apiv1beta2
-    domain_layer_location: cloud.google.com/go/videointelligence
   csharp:
     package_name: Google.Cloud.VideoIntelligence.V1Beta2
   ruby:


### PR DESCRIPTION
The location should only be used by generated clients without
handwritten counterpart.
Currently, the doc will say "please use this handwritten client
instead" when the said client does not exist.