### PR TITLE
Add artman-genfiles/ to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ README.google
 google/internal
 google/protobuf
 .project
+artman-genfiles/


### PR DESCRIPTION
The new `artman2` currently only runs from the root of this repo (I will fix this today). Ignore its output by default.