### PR TITLE
bump java proto version to 0.1.20 for new proto/grpc release

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -39,7 +39,7 @@ generated_package_version:
   ruby:
     lower: '0.6.8'
   java:
-    lower: '0.1.19'
+    lower: '0.1.20'
 
 generated_ga_package_version:
   java:

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -84,7 +84,7 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.3.1'
   java:
-    lower: '0.1.19'
+    lower: '0.1.20'
 
 google-iam-v1_version:
   python:
@@ -95,7 +95,7 @@ google-iam-v1_version:
     name_override: grpc-google-iam-v1
     lower: '0.6.8'
   java:
-    lower: '0.1.19'
+    lower: '0.1.20'
 
 api_common_version:
   java:


### PR DESCRIPTION
New proto/grpc release in https://github.com/googleapis/api-client-staging/pull/416.