### PR TITLE
NodeJS: Remove dependency on nodejs-proto-files

### DIFF
--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -81,9 +81,6 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.5.2'
     upper: '2.0dev'
-  nodejs:
-    name_override: google-proto-files
-    lower: '0.12.0'
   ruby:
     name_override: googleapis-common-protos
     lower: '1.3.1'


### PR DESCRIPTION
Gax now handles it.