### PR TITLE
Update Python generator ID

### DIFF
--- a/gapic/lang/python_gapic.yaml
+++ b/gapic/lang/python_gapic.yaml
@@ -2,4 +2,4 @@ type: com.google.api.codegen.ConfigProto
 language: python
 generator:
   factory: com.google.api.codegen.gapic.MainGapicProviderFactory
-  id: python
+  id: py


### PR DESCRIPTION
https://github.com/googleapis/toolkit/pull/1522 made the Python ID "py", not "python".

I believe the source of truth for this file is GitHub, not Google repo. So making the change here.