### PR TITLE
Run artman smoketests in googleapis circleci project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,24 @@ jobs:
               git push private HEAD:master
             fi
     working_directory: /var/code/googleapis/
+  smoke-all:
+    docker:
+      - image: googleapis/artman:stable
+    steps:
+      - checkout
+      - run:
+          name: Run smoke tests
+          command: |
+            mkdir /tmp/reports
+            smoketest_artman.py --root-dir=/var/code/googleapis/ --log=/tmp/reports/smoketest.log
+      - store_test_results:
+          path: /tmp/reports
+      - store_artifacts:
+          path: /tmp/reports
+    working_directory: /var/code/googleapis/
+
+workflows:
+  version: 2
+  smoketests:
+    jobs:
+      - smoke-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,7 @@ workflows:
   version: 2
   smoketests:
     jobs:
-      - smoke-all
+      - smoke-all:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Using the same smoketest script that artman uses. Different from the circleci task, we uses a stable artman image to run the smoketests. This way, we can be notified if one googleapis commit causes some artifact fail to generate. Currently, some artifacts fail to generate, causing noisyness. This task will be more useful once all artifacts in googleapis are working.