### PR TITLE
Fix a flaw in smoketests CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           name: Run smoke tests
           command: |
             mkdir /tmp/reports
+            export RUNNING_IN_ARTMAN_DOCKER=True
             smoketest_artman.py --root-dir=/var/code/googleapis/ --log=/tmp/reports/smoketest.log
       - store_test_results:
           path: /tmp/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,24 @@ jobs:
               git push private HEAD:master
             fi
     working_directory: /var/code/googleapis/
+  smoke-all:
+    docker:
+      - image: googleapis/artman:stable
+    steps:
+      - checkout
+      - run:
+          name: Run smoke tests
+          command: |
+            mkdir /tmp/reports
+            smoketest_artman.py --root-dir=/var/code/googleapis/ --log=/tmp/reports/smoketest.log
+      - store_test_results:
+          path: /tmp/reports
+      - store_artifacts:
+          path: /tmp/reports
+    working_directory: /var/code/googleapis/
+
+workflows:
+  version: 2
+  smoketests:
+    jobs:
+      - smoke-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,7 @@ workflows:
   version: 2
   smoketests:
     jobs:
-      - smoke-all
+      - smoke-all:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Specify additional env var so that the artman docker container that runs the smoketests knows to use the cached gapic yamls instead of the latest ones. This will match the behavior of `artman2`.