### PR TITLE
Change Ruby package metadata defaults

### DIFF
--- a/gapic/packaging/api_defaults.yaml
+++ b/gapic/packaging/api_defaults.yaml
@@ -37,7 +37,7 @@ generated_package_version:
   php:
     lower: '0.1.0'
   ruby:
-    lower: '0.6.8'
+    lower: '0.1.0'
   java:
     lower: '0.1.22'
 

--- a/gapic/packaging/dependencies.yaml
+++ b/gapic/packaging/dependencies.yaml
@@ -23,7 +23,7 @@ auth_version:
   nodejs:
     lower: '0.9.8'
   ruby:
-    lower: '0.5.1'
+    lower: '0.6.1'
 
 grpc_version:
   csharp:


### PR DESCRIPTION
- Bump googleauth dependency to 0.6.1 to pick up new credentials class
  required by GAPIC.
- Reset default version to 0.1.0. Brand-new package should have this
  version. All other packages should have their version maintained
  manually or through the artman config.