### PR TITLE
Firestore Field Names Documentation

### DIFF
--- a/google/firestore/v1beta1/document.proto
+++ b/google/firestore/v1beta1/document.proto
@@ -42,25 +42,23 @@ message Document {
   // The map keys represent field names.
   //
   // A simple field name contains only characters `a` to `z`, `A` to `Z`,
-  // `0` to `9`, or `_`, and must not start with `0` to `9` or `_`. For example,
-  // `foo_bar_17`.
-  //
-  // Field names matching the regular expression `__.*__` are reserved. Reserved
-  // field names are forbidden except in certain documented contexts. The map
-  // keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be
-  // empty.
+  // `0` to `9`, or `_`, and must not start with `0` to `9`. For example,
+  // `foo_bar_17`.  Field names matching the regular expression `__.*__`
+  // are reserved. Reserved field names are forbidden except in certain
+  // documented contexts.
   //
   // Field paths may be used in other contexts to refer to structured fields
-  // defined here. For `map_value`, the field path is represented by the simple
-  // or quoted field names of the containing fields, delimited by `.`. For
-  // example, the structured field
-  // `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be
-  // represented by the field path `foo.x&y`.
+  // defined here. For `map_value`, the field path is either represented by
+  // the simple field name, or alternatively can be represented as a quoted
+  // UTF-8 string delimited by `.`.  A quoted field path starts and ends
+  // with `` ` ``.  However, the characters `` ` `` and `` \ `` must be
+  // escaped using `\`.  For example, `` `x&y` `` represents `x&y` and
+  // `` `bak\`tik` `` represents `` bak`tik ``.  In addition, the structured
+  // field:
+  // `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}`
+  // would be represented by the field path `foo.x&y`.  However, it must not
+  // exceed 1,500 bytes or be empty.
   //
-  // Within a field path, a quoted field name starts and ends with `` ` `` and
-  // may contain any character. Some characters, including `` ` ``, must be
-  // escaped using a `\`. For example, `` `x&y` `` represents `x&y` and
-  // `` `bak\`tik` `` represents `` bak`tik ``.
   map<string, Value> fields = 2;
 
   // Output only. The time at which the document was created.


### PR DESCRIPTION
How do I render the documentation locally to see what it looks like?

@jba I corrected the regex expression, and changed the wording.  I think what I wrote is correct given what we discussed, but please feel free to correct me.  I hope that this is a bit clearer in describing what a field path is.