### PR TITLE
Store artifacts in CircleCI for files under /var/code/googleapis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
           path: /tmp/reports
       - store_artifacts:
           path: /tmp/reports
+      - store_artifacts:
+          path: /var/code/googleapis
     working_directory: /var/code/googleapis/
 
 workflows:


### PR DESCRIPTION
That folder will include outputs from smoketest. And those output could be very help for verification.