### PR TITLE
Make additional_bindings body declaration consistent

### DIFF
--- a/google/cloud/speech/speech.yaml
+++ b/google/cloud/speech/speech.yaml
@@ -46,6 +46,7 @@ http:
     body: '*'
     additional_bindings:
     - post: '/v1beta1/operations/{name=*}:cancel'
+      body: '*'
 
 
 authentication:


### PR DESCRIPTION
See [dlp.yaml](https://github.com/googleapis/googleapis/blob/112ffe43cc2c9ebb25ad15dcdf130a3a57a72ba0/google/privacy/dlp/dlp.yaml#L86) and [runtimeconfig.yaml](https://github.com/googleapis/googleapis/blob/64466c30458b499722f308b66ce9a5e2519fc269/google/cloud/runtimeconfig/runtimeconfig.yaml#L32) for examples of how this should be. Additional Bindings redeclare the `body` parameter as well.