### PR TITLE
Makefile: node output flag difference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,12 @@ $(error Go source files are not generated from this repository. See: https://git
 endif
 
 FLAGS+= --proto_path=.:$(PROTOINCLUDE)
-FLAGS+= --$(LANGUAGE)_out=$(OUTPUT) --grpc_out=$(OUTPUT)
+ifeq ($(LANGUAGE), node)
+FLAGS+= --js_out=import_style=commonjs,binary:$(OUTPUT)
+else
+FLAGS+= --$(LANGUAGE)_out=$(OUTPUT)
+endif
+FLAGS+= --grpc_out=$(OUTPUT)
 FLAGS+=	--plugin=protoc-gen-grpc=$(GRPCPLUGIN)
 
 SUFFIX:= pb.cc


### PR DESCRIPTION
Since the plugin file's name is `grpc_node_plugin`, the code I should run to generate nodejs' pb files is `make LANGUAGE=node `. However, it won't generate pb files unless I change `node_out` to `js_out`.