### PR TITLE
remove discogapic from common.yaml

### DIFF
--- a/gapic/lang/common.yaml
+++ b/gapic/lang/common.yaml
@@ -7,8 +7,6 @@ common:
 java:
   gapic_language_yaml:
     - ${GOOGLEAPIS}/gapic/lang/java_gapic.yaml
-  discogapic_language_yaml:
-    - ${GOOGLEAPIS}/gapic/lang/java_discogapic.yam
 python:
   gapic_language_yaml:
     - ${GOOGLEAPIS}/gapic/lang/python_gapic.yaml


### PR DESCRIPTION
Everything has been migrated over to discovery-artifact-manager.