### PR TITLE
Exclude APIs with (experimental) version 0 from CPP build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ FLAGS+=	--plugin=protoc-gen-grpc=$(GRPCPLUGIN)
 
 SUFFIX:= pb.cc
 
-DEPS:= $(shell find google $(PROTOINCLUDE)/google/protobuf -type f -name '*.proto' | sed "s/proto$$/$(SUFFIX)/")
+DEPS:= $(shell find google $(PROTOINCLUDE)/google/protobuf -type f -name '*.proto' -not -path '*/v0/*' | sed "s/proto$$/$(SUFFIX)/")
 
 all: $(DEPS)
 


### PR DESCRIPTION
The main reason for this PR is that the recently committed Google Ads API does break the CPP client stub generation. Unfortunately, this is not caught by the CircleCI build/test script which only tests _Artman_-based generation.
