### PR TITLE
Add response field to HttRule

### DIFF
--- a/google/api/http.proto
+++ b/google/api/http.proto
@@ -297,6 +297,13 @@ message HttpRule {
   // present at the top-level of request message type.
   string body = 7;
 
+  // The name of the response field whose value is mapped to the HTTP body of response.
+  // Other response fields are ignored. This field is optional. When not set,
+  // the response message will be used as HTTP body of response.
+  // NOTE: the referred field must be not a repeated field and must be
+  // present at the top-level of response message type.
+  string response_body = 9;
+
   // Additional HTTP bindings for the selector. Nested bindings must
   // not contain an `additional_bindings` field themselves (that is,
   // the nesting may only be one level deep).


### PR DESCRIPTION
This PR adds optional field `response_body` from spec: https://cloud.google.com/service-management/reference/rpc/google.api#google.api.HttpRule