### PR TITLE
Correct the spelling of UNIMPLEMENTED.

### DIFF
--- a/google/devtools/remoteexecution/v1test/remote_execution.proto
+++ b/google/devtools/remoteexecution/v1test/remote_execution.proto
@@ -142,7 +142,7 @@ service ActionCache {
   // result, it is OPTIONAL for servers to implement.
   //
   // Errors:
-  // * `NOT_IMPLEMENTED`: This method is not supported by the server.
+  // * `UNIMPLEMENTED`: This method is not supported by the server.
   // * `RESOURCE_EXHAUSTED`: There is insufficient storage space to add the
   //   entry to the cache.
   rpc UpdateActionResult(UpdateActionResultRequest) returns (ActionResult) {


### PR DESCRIPTION
NOT_IMPLEMENTED doesn't seem to be an actual GRPC error code.