### PR TITLE
Add resource.path to Subscription message

### DIFF
--- a/google/pubsub/v1/pubsub.proto
+++ b/google/pubsub/v1/pubsub.proto
@@ -607,7 +607,7 @@ message Subscription {
   // in length, and it must not start with `"goog"`.
   string name = 1 [
       (google.api.required) = true,
-      (google.api.resource).path = "projects/{project}/subscriptions/{sub}"];
+      (google.api.resource).path = "projects/*/subscriptions/*}"];
 
   // The name of the topic from which this subscription is receiving messages.
   // Format is `projects/{project}/topics/{topic}`.

--- a/google/pubsub/v1/pubsub.proto
+++ b/google/pubsub/v1/pubsub.proto
@@ -607,7 +607,7 @@ message Subscription {
   // in length, and it must not start with `"goog"`.
   string name = 1 [
       (google.api.required) = true,
-      (google.api.resource_type) = "google.pubsub.v1.Subscription"];
+      (google.api.resource).path = "projects/{project}/subscriptions/{sub}"];
 
   // The name of the topic from which this subscription is receiving messages.
   // Format is `projects/{project}/topics/{topic}`.


### PR DESCRIPTION
Just want a sanity check to verify that this is how ResourceTypes work.

Currently there's a circular reference between Subscription.name and Subscription. Nowhere, outside of comments, is there a definition for the resource path template that identifies a Subscription. This fixes that.