### PR TITLE
[DO NOT MERGE] IOT Proto-annotations (new style)

### DIFF
--- a/google/cloud/iot/v1/device_manager.proto
+++ b/google/cloud/iot/v1/device_manager.proto
@@ -31,6 +31,24 @@ option java_multiple_files = true;
 option java_outer_classname = "DeviceManagerProto";
 option java_package = "com.google.cloud.iot.v1";
 
+// Add resources to imported types.
+// See alternative, where this can be specified within the RPC method declaration.
+// In that case, these options will not be needed.
+option (google.api.resource_imported_reference) = {
+  type_name: "google.iam.v1.SetIamPolicyRequest",
+  // field_name: "resource", // Infered when there is only one string field in the message.
+  resource_reference: "iam" // Defined in resources.proto; but in the same namespace as this file
+};
+option (google.api.resource_imported_reference) = {
+  type_name: "google.iam.v1.GetIamPolicyRequest",
+  // field_name: "resource", // Infered when there is only one string field in the message.
+  resource_reference: "iam" // Defined in resources.proto; but in the same namespace as this file
+};
+option (google.api.resource_imported_reference) = {
+  type_name: "google.iam.v1.TestIamPermissionsRequest",
+  // field_name: "resource", // Infered when there is only one string field in the message.
+  resource_reference: "iam" // Defined in resources.proto; but in the same namespace as this file
+};
 
 // Internet of things (IoT) service. Allows to manipulate device registry
 // instances and the registration of devices (Things) to the cloud.
@@ -169,8 +187,14 @@ service DeviceManager {
         body: "*"
       }
     };
+    // Alternatively the imported reference can be placed in the method declaration.
+    // The "resource_imported_request_reference" states it's for the request proto message.
+    // "field_name" is optional in the case then the request message only contains one
+    // string field. If it's omitted when there are multiple string fields then the
+    // generator will fail with an "ambiguous resource field" error.
+    option (google.api.resource_imported_request_reference).resource_reference = "iam";
   }
-
+  
   // Gets the access control policy for a resource.
   // Returns an empty policy if the resource exists and does not have a policy
   // set.
@@ -183,6 +207,12 @@ service DeviceManager {
         body: "*"
       }
     };
+    // Alternatively the imported reference can be placed in the method declaration.
+    // The "resource_imported_request_reference" states it's for the request proto message.
+    // "field_name" is optional in the case then the request message only contains one
+    // string field. If it's omitted when there are multiple string fields then the
+    // generator will fail with an "ambiguous resource field" error.
+    option (google.api.resource_imported_request_reference).resource_reference = "iam";
   }
 
   // Returns permissions that a caller has on the specified resource.
@@ -197,6 +227,12 @@ service DeviceManager {
         body: "*"
       }
     };
+    // Alternatively the imported reference can be placed in the method declaration.
+    // The "resource_imported_request_reference" states it's for the request proto message.
+    // "field_name" is optional in the case then the request message only contains one
+    // string field. If it's omitted when there are multiple string fields then the
+    // generator will fail with an "ambiguous resource field" error.
+    option (google.api.resource_imported_request_reference).resource_reference = "iam";
   }
 }
 
@@ -204,7 +240,7 @@ service DeviceManager {
 message CreateDeviceRegistryRequest {
   // The project and cloud region where this device registry must be created.
   // For example, `projects/example-project/locations/us-central1`.
-  string parent = 1;
+  string parent = 1 [(google.api.resource_reference) = "location"];
 
   // The device registry. The field `name` must be empty. The server will
   // generate that field from the device registry `id` provided and the
@@ -216,14 +252,14 @@ message CreateDeviceRegistryRequest {
 message GetDeviceRegistryRequest {
   // The name of the device registry. For example,
   // `projects/example-project/locations/us-central1/registries/my-registry`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "registry"];
 }
 
 // Request for `DeleteDeviceRegistry`.
 message DeleteDeviceRegistryRequest {
   // The name of the device registry. For example,
   // `projects/example-project/locations/us-central1/registries/my-registry`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "registry"];
 }
 
 // Request for `UpdateDeviceRegistry`.
@@ -231,7 +267,7 @@ message UpdateDeviceRegistryRequest {
   // The new values for the device registry. The `id` field must be empty, and
   // the `name` field must indicate the path of the resource. For example,
   // `projects/example-project/locations/us-central1/registries/my-registry`.
-  DeviceRegistry device_registry = 1;
+  DeviceRegistry device_registry = 1 [(google.api.resource_reference) = "regisrty"];
 
   // Only updates the `device_registry` fields indicated by this mask.
   // The field mask must not be empty, and it must not contain fields that
@@ -245,7 +281,7 @@ message UpdateDeviceRegistryRequest {
 message ListDeviceRegistriesRequest {
   // The project and cloud region path. For example,
   // `projects/example-project/locations/us-central1`.
-  string parent = 1;
+  string parent = 1 [(google.api.resource_reference) = "location"];
 
   // The maximum number of registries to return in the response. If this value
   // is zero, the service will select a default size. A call may return fewer
@@ -275,7 +311,7 @@ message CreateDeviceRequest {
   // The name of the device registry where this device should be created.
   // For example,
   // `projects/example-project/locations/us-central1/registries/my-registry`.
-  string parent = 1;
+  string parent = 1 [(google.api.resource_reference) = "registry"];
 
   // The device registration details. The field `name` must be empty. The server
   // will generate that field from the device registry `id` provided and the
@@ -288,7 +324,7 @@ message GetDeviceRequest {
   // The name of the device. For example,
   // `projects/p0/locations/us-central1/registries/registry0/devices/device0` or
   // `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "device"];
 
   // The fields of the `Device` resource to be returned in the response. If the
   // field mask is unset or empty, all fields are returned.
@@ -315,14 +351,14 @@ message DeleteDeviceRequest {
   // The name of the device. For example,
   // `projects/p0/locations/us-central1/registries/registry0/devices/device0` or
   // `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "device"];
 }
 
 // Request for `ListDevices`.
 message ListDevicesRequest {
   // The device registry path. Required. For example,
   // `projects/my-project/locations/us-central1/registries/my-registry`.
-  string parent = 1;
+  string parent = 1 [(google.api.resource_reference) = "registry"];
 
   // A list of device numerical ids. If empty, it will ignore this field. This
   // field cannot hold more than 10,000 entries.
@@ -365,7 +401,7 @@ message ModifyCloudToDeviceConfigRequest {
   // The name of the device. For example,
   // `projects/p0/locations/us-central1/registries/registry0/devices/device0` or
   // `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "device"];
 
   // The version number to update. If this value is zero, it will not check the
   // version number of the server and will always update the current version;
@@ -383,7 +419,7 @@ message ListDeviceConfigVersionsRequest {
   // The name of the device. For example,
   // `projects/p0/locations/us-central1/registries/registry0/devices/device0` or
   // `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "device"];
 
   // The number of versions to list. Versions are listed in decreasing order of
   // the version number. The maximum number of versions retained is 10. If this
@@ -403,7 +439,7 @@ message ListDeviceStatesRequest {
   // The name of the device. For example,
   // `projects/p0/locations/us-central1/registries/registry0/devices/device0` or
   // `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference) = "device"];
 
   // The number of states to list. States are listed in descending order of
   // update time. The maximum number of states retained is 10. If this

--- a/google/cloud/iot/v1/resources.proto
+++ b/google/cloud/iot/v1/resources.proto
@@ -26,6 +26,40 @@ option java_multiple_files = true;
 option java_outer_classname = "ResourcesProto";
 option java_package = "com.google.cloud.iot.v1";
 
+// resource_definitons are defined at file level.
+// May be referred to either locally: "location"; or fully-qualified: "google.cloud.iot.v1:location"
+// Alternatively, these definitions may be placed on the field within the resource message.
+// In this file, this means the "Device" and "Registry" messages.
+option (google.api.resource_definition) = {
+  name: "location",
+  path: "projects/{project}/locations/{location}"
+};
+option (google.api.resource_definition) = {
+  name: "device",
+  path: "projects/{project}/locations/{location}/registries/{registry}/devices/{device}"
+};
+option (google.api.resource_definition) = {
+  name: "registry",
+  path: "projects/{project}/locations/{location}/registries/{registry}"
+};
+// Re-define pubsub topic here, so we don't need a pubsub dependency.
+// This is a duplicate of the resource_definition in pubsub.
+// This will create a distinct type, different from the Topic resource in pubsub.
+// Alternatively, a dependency on pubsub could be added, then this entity would not be needed.
+option (google.api.resource_definition) = {
+  name: "pubsub_topic",
+  base_name: "topic", // "base_name" only required when different from "name"
+  path: "projects/{project}/topics/{topic}"
+};
+// Resources on the imported iam messages.
+option (google.api.resource_definition) = {
+  name: "group",
+  path: "resource=projects/{project}/locations/{location}/registries/{registry}/groups/{group}"
+};
+option (google.api.resource_set_definition) = {
+  name: "iam",
+  resource_names: ["registry", "group"]
+};
 
 // The device resource.
 message Device {
@@ -38,7 +72,12 @@ message Device {
   // `projects/p1/locations/us-central1/registries/registry0/devices/{num_id}`.
   // When `name` is populated as a response from the service, it always ends
   // in the device numeric ID.
-  string name = 2;
+  string name = 2 [(google.api.resource_reference) = "device"];
+  // Alternatively, if the resource is being defined within this message.
+  // An implied resource_reference is also specified on this field.
+  // "name" and "base_name" are both inferred to be the message name,
+  // "Device" in this case - decisions will be required about casing of generated classes.
+  string name = 2 [(google.api.resource_definition).path = "projects/{project}/locations/{location}/registries/{registry}/devices/{device}"];
 
   // [Output only] A server-defined unique numeric ID for the device. This is a
   // more compact way to identify devices, and it is globally unique.
@@ -128,7 +167,12 @@ message DeviceRegistry {
 
   // The resource path name. For example,
   // `projects/example-project/locations/us-central1/registries/my-registry`.
-  string name = 2;
+  string name = 2 [(google.api.resource_reference) = "registry"];
+  // Alternatively, if the resource is being defined within this message.
+  // An implied resource_reference is also specified on this field.
+  // "name" and "base_name" are both inferred to be the message name,
+  // "DeviceRegistry" in this case - decisions will be required about casing of generated classes.
+  string name = 2 [(google.api.resource_definition).path = "projects/{project}/locations/{location}/registries/{registry}"];
 
   // The configuration for notification of telemetry events received from the
   // device. All telemetry events that were successfully published by the
@@ -193,14 +237,18 @@ message EventNotificationConfig {
 
   // A Cloud Pub/Sub topic name. For example,
   // `projects/myProject/topics/deviceEvents`.
-  string pubsub_topic_name = 1;
+  string pubsub_topic_name = 1 [(google.api.resource_reference) = "pubsub_topic"];
+  // NOTE: If there was a dependency on pubsub, this field would be:
+  string pubsub_topic_name = 1 [(google.api.resource_reference) = "google.api.pubsub.v1:topic"];
 }
 
 // The configuration for notification of new states received from the device.
 message StateNotificationConfig {
   // A Cloud Pub/Sub topic name. For example,
   // `projects/myProject/topics/deviceEvents`.
-  string pubsub_topic_name = 1;
+  string pubsub_topic_name = 1 [(google.api.resource_reference) = "pubsub_topic"];
+  // NOTE: If there was a dependency on pubsub, this field would be:
+  string pubsub_topic_name = 1 [(google.api.resource_reference) = "google.api.pubsub.v1:topic"];
 }
 
 // A server-stored registry credential used to validate device credentials.

--- a/google/iam/v1/iam_policy.proto
+++ b/google/iam/v1/iam_policy.proto
@@ -80,7 +80,8 @@ message SetIamPolicyRequest {
   // REQUIRED: The resource for which the policy is being specified.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  string resource = 1;
+  // Note: Special reference for an "any" resource, reference to "**" doesn't require a resource_definition
+  string resource = 1 [(google.api.resource_reference) = "**"];
 
   // REQUIRED: The complete policy to be applied to the `resource`. The size of
   // the policy is limited to a few 10s of KB. An empty policy is a
@@ -94,7 +95,8 @@ message GetIamPolicyRequest {
   // REQUIRED: The resource for which the policy is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  string resource = 1;
+  // Note: Special reference for an "any" resource, reference to "**" doesn't require a resource_definition
+  string resource = 1 [(google.api.resource_reference) = "**"];
 }
 
 // Request message for `TestIamPermissions` method.
@@ -102,7 +104,8 @@ message TestIamPermissionsRequest {
   // REQUIRED: The resource for which the policy detail is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  string resource = 1;
+  // Note: Special reference for an "any" resource, reference to "**" doesn't require a resource_definition
+  string resource = 1 [(google.api.resource_reference) = "**"];
 
   // The set of permissions to check for the `resource`. Permissions with
   // wildcards (such as '*' or 'storage.*') are not allowed. For more


### PR DESCRIPTION
This only contains annotations for resource-names, as this PR is to help resolve remaining issues with resource-name annotations for imported messages.

This is an experimental, alternative, way of declaring resources that is not as defined in the specification