### PR TITLE
Remove references to google.api.Project; create resource def for projects/{project}

### DIFF
--- a/google/pubsub/v1/pubsub.proto
+++ b/google/pubsub/v1/pubsub.proto
@@ -38,7 +38,7 @@ option (google.api.metadata) = {
 };
 
 option (google.api.resource_definition) = {
-  name: "project"
+  name: "Project"
   path: "projects/{project}"
 };
 
@@ -505,7 +505,7 @@ message ListTopicsRequest {
   // Format is `projects/{project}`.
   string project = 1 [
       (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference) = "project"];
+      (google.api.resource_reference) = "Project"];
 
   // Maximum number of topics to return.
   int32 page_size = 2;
@@ -735,7 +735,7 @@ message ListSubscriptionsRequest {
   // Format is `projects/{project}`.
   string project = 1 [
       (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference) = "project"];
+      (google.api.resource_reference) = "Project"];
 
   // Maximum number of subscriptions to return.
   int32 page_size = 2;
@@ -992,7 +992,7 @@ message ListSnapshotsRequest {
   // Format is `projects/{project}`.
   string project = 1 [
       (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference) = "project"];
+      (google.api.resource_reference) = "Project"];
 
   // Maximum number of snapshots to return.
   int32 page_size = 2;

--- a/google/pubsub/v1/pubsub.proto
+++ b/google/pubsub/v1/pubsub.proto
@@ -37,6 +37,10 @@ option (google.api.metadata) = {
   package_namespace: ["Google", "Cloud"]
 };
 
+option (google.api.resource_definition) = {
+  name: "project"
+  path: "projects/{project}"
+};
 
 // The service that an application uses to manipulate topics, and to send
 // messages to a topic.
@@ -501,7 +505,7 @@ message ListTopicsRequest {
   // Format is `projects/{project}`.
   string project = 1 [
       (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference) = "google.api.Project"];
+      (google.api.resource_reference) = "project"];
 
   // Maximum number of topics to return.
   int32 page_size = 2;
@@ -731,7 +735,7 @@ message ListSubscriptionsRequest {
   // Format is `projects/{project}`.
   string project = 1 [
       (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference) = "google.api.Project"];
+      (google.api.resource_reference) = "project"];
 
   // Maximum number of subscriptions to return.
   int32 page_size = 2;
@@ -988,7 +992,7 @@ message ListSnapshotsRequest {
   // Format is `projects/{project}`.
   string project = 1 [
       (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference) = "google.api.Project"];
+      (google.api.resource_reference) = "project"];
 
   // Maximum number of snapshots to return.
   int32 page_size = 2;


### PR DESCRIPTION
`google.api.Project` was removed in https://github.com/googleapis/api-common-protos/pull/20/files.