### PR TITLE
Dropped unused load from BUILD file

### DIFF
--- a/google/rpc/BUILD.bazel
+++ b/google/rpc/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-
 # This is an API workspace, having public visibility by default makes perfect sense.
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
The java_grpc_library was not used in this BUILD file. Removing this allows other repositories to reference the proto libraries in this package without importing the java grpc repo.