### PR TITLE
Add C++ Bazel rules for Spanner protobuf and gRPC

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,3 +97,15 @@ gazelle_dependencies()
 load("@com_google_api_codegen//rules_gapic/go:go_gapic_repositories.bzl", "go_gapic_repositories")
 
 go_gapic_repositories()
+
+http_archive(
+    name = "com_github_grpc_grpc",
+    urls = [
+        "https://github.com/grpc/grpc/archive/cb9b43b9f7291ceb714d92e0a717c6364c1fcc61.zip",
+    ],
+    strip_prefix = "grpc-cb9b43b9f7291ceb714d92e0a717c6364c1fcc61",
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", com_github_grpc_grpc_bazel_grpc_deps = "grpc_deps")
+
+com_github_grpc_grpc_bazel_grpc_deps()

--- a/google/api/BUILD.bazel
+++ b/google/api/BUILD.bazel
@@ -362,3 +362,62 @@ go_proto_library(
         ":monitoredres_go_proto",
     ],
 )
+
+##############################################################################
+# C++
+##############################################################################
+
+cc_proto_library(
+    name = "annotations_cc_proto",
+    deps = [":annotations_proto"],
+)
+
+cc_proto_library(
+    name = "client_cc_proto",
+    deps = [":client_proto"],
+)
+
+cc_proto_library(
+    name = "configchange_cc_proto",
+    deps = [":config_change_proto"],
+)
+
+cc_proto_library(
+    name = "distribution_cc_proto",
+    deps = [":distribution_proto"],
+)
+
+cc_proto_library(
+    name = "field_behavior_cc_proto",
+    deps = [":field_behavior_proto"],
+)
+
+cc_proto_library(
+    name = "httpbody_cc_proto",
+    deps = [":httpbody_proto"],
+)
+
+cc_proto_library(
+    name = "label_cc_proto",
+    deps = [":label_proto"],
+)
+
+cc_proto_library(
+    name = "launch_stage_cc_proto",
+    deps = [":launch_stage_proto"],
+)
+
+cc_proto_library(
+    name = "metric_cc_proto",
+    deps = [":metric_proto"],
+)
+
+cc_proto_library(
+    name = "monitored_resource_cc_proto",
+    deps = [":monitored_resource_proto"],
+)
+
+cc_proto_library(
+    name = "resource_cc_proto",
+    deps = [":resource_proto"],
+)

--- a/google/spanner/v1/BUILD.bazel
+++ b/google/spanner/v1/BUILD.bazel
@@ -7,23 +7,77 @@ package(default_visibility = ["//visibility:public"])
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_library_with_info")
 
 proto_library(
-    name = "spanner_proto",
-    srcs = [
-        "keys.proto",
-        "mutation.proto",
-        "query_plan.proto",
-        "result_set.proto",
-        "spanner.proto",
-        "transaction.proto",
-        "type.proto",
-    ],
+    name = "keys_proto",
+    srcs = ["keys.proto"],
     deps = [
         "//google/api:annotations_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "mutation_proto",
+    srcs = ["mutation.proto"],
+    deps = [
+        ":keys_proto",
+        "//google/api:annotations_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "query_plan_proto",
+    srcs = ["query_plan.proto"],
+    deps = [
+        "//google/api:annotations_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "result_set_proto",
+    srcs = ["result_set.proto"],
+    deps = [
+        ":query_plan_proto",
+        ":transaction_proto",
+        ":type_proto",
+        "//google/api:annotations_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "spanner_proto",
+    srcs = ["spanner.proto"],
+    deps = [
+        ":keys_proto",
+        ":mutation_proto",
+        ":result_set_proto",
+        ":transaction_proto",
+        ":type_proto",
+        "//google/api:annotations_proto",
         "//google/rpc:status_proto",
-        "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:empty_proto",
         "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "transaction_proto",
+    srcs = ["transaction.proto"],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "//google/api:annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "type_proto",
+    srcs = ["type.proto"],
+    deps = [
+        "//google/api:annotations_proto",
     ],
 )
 
@@ -145,5 +199,63 @@ go_gapic_assembly_pkg(
         ":spanner_go_gapic_srcjar-smoke-test.srcjar",
         ":spanner_go_gapic_srcjar-test.srcjar",
         ":spanner_go_proto",
+    ],
+)
+
+##############################################################################
+# C++
+##############################################################################
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+
+cc_proto_library (
+    name = "keys_cc_proto",
+    deps = [":keys_proto"],
+)
+
+cc_proto_library (
+    name = "mutation_cc_proto",
+    deps = [":mutation_proto"],
+)
+
+cc_proto_library (
+    name = "query_plan_cc_proto",
+    deps = [":query_plan_proto"],
+)
+
+cc_proto_library (
+    name = "type_cc_proto",
+    deps = [":type_proto"],
+)
+
+cc_proto_library (
+    name = "transaction_cc_proto",
+    deps = [":transaction_proto"],
+)
+
+cc_proto_library (
+    name = "result_set_cc_proto",
+    deps = [":result_set_proto"],
+)
+
+cc_proto_library (
+    name = "spanner_cc_proto",
+    deps = [
+        ":spanner_proto",
+    ],
+)
+
+cc_grpc_library(
+    name = "spanner_cc_grpc",
+    srcs = [":spanner_proto"],
+    grpc_only = True,
+    well_known_protos = True,
+    deps = [
+        ":spanner_cc_proto",
+        ":transaction_cc_proto",
+        ":type_cc_proto",
+        "//google/api:annotations_cc_proto",
+        ":keys_cc_proto",
+        ":mutation_cc_proto",
+        ":result_set_cc_proto",
     ],
 )


### PR DESCRIPTION
Fixes dependencies for the proto_library rules to allow it to build.