### PR TITLE
Add C++ version of pubsub proto

### DIFF
--- a/google/pubsub/v1/BUILD.bazel
+++ b/google/pubsub/v1/BUILD.bazel
@@ -192,3 +192,24 @@ php_gapic_assembly_pkg(
         ":pubsub_php_proto",
     ],
 )
+
+##############################################################################
+# C++
+##############################################################################
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
+cc_proto_library(
+    name = "pubsub_cc_proto",
+    deps = [":pubsub_proto"],
+)
+
+cc_grpc_library(
+    name = "pubsub_cc_grpc",
+    srcs = [":pubsub_proto"],
+    deps = [":pubsub_cc_proto"],
+   grpc_only = True,
+)


### PR DESCRIPTION
This fix add C++ version of pubsub proto (Java and GO have already been added)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>