### PR TITLE
Tweak output package name for Python Firestore admin client.

### DIFF
--- a/google/firestore/admin/v1/firestore_gapic.yaml
+++ b/google/firestore/admin/v1/firestore_gapic.yaml
@@ -4,7 +4,7 @@ language_settings:
   java:
     package_name: com.google.cloud.firestore.v1
   python:
-    package_name: google.cloud.firestore_v1.gapic
+    package_name: google.cloud.firestore_admin_v1.gapic
   go:
     package_name: cloud.google.com/go/firestore/apiv1/admin
   csharp:


### PR DESCRIPTION
For comparison, see: https://github.com/googleapis/googleapis/blob/47bd0c2ba33c28dd624a65dad382e02bb61d1618/google/bigtable/admin/v2/bigtableadmin_gapic.yaml#L10