### PR TITLE
Remove old comment in publish_build_event.proto

### DIFF
--- a/google/devtools/build/v1/publish_build_event.proto
+++ b/google/devtools/build/v1/publish_build_event.proto
@@ -148,7 +148,6 @@ message OrderedBuildEvent {
 // Streaming request message for PublishBuildToolEventStream.
 message PublishBuildToolEventStreamRequest {
   // The build event with position info.
-  // New publishing clients should use this field rather than the 3 above.
   OrderedBuildEvent ordered_build_event = 4;
 
   // The keywords to be attached to the notification which notifies the start


### PR DESCRIPTION
This line refers to fields which don't exist.