### PR TITLE
speedup CI by saving one .tgz file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,4 +43,3 @@ workflows:
             branches:
               only:
                 - master
-                - speedup-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,4 +41,6 @@ workflows:
       - smoke-all:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - speedup-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,14 @@ jobs:
             mkdir /tmp/reports
             export RUNNING_IN_ARTMAN_DOCKER=True
             smoketest_artman.py --root-dir=/var/code/googleapis/ --log=/tmp/reports/smoketest.log
+            mkdir /var/code/googleapis-tgz
+            tar cfz /var/code/googleapis-tgz/googleapis.tar.gz /var/code/googleapis
       - store_test_results:
           path: /tmp/reports
       - store_artifacts:
           path: /tmp/reports
       - store_artifacts:
-          path: /var/code/googleapis
+          path: /var/code/googleapis-tgz
     working_directory: /var/code/googleapis/
 
 workflows:


### PR DESCRIPTION
With the current size of `googleapis`, CI takes about an hour to run, and sometimes 2 hours or more to save all the artifacts (generated files for all languages × all APIs). Let's try to speed up the second part by saving just one big `.tar.gz` file instead.

The log will still be available in CircleCI artifacts page since `/tmp/reports` folder is saved separately.