### PR TITLE
Adding non-native proto_library rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -184,3 +184,19 @@ php(
 )
 
 php_gapic_repositories()
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()

--- a/google/api/BUILD.bazel
+++ b/google/api/BUILD.bazel
@@ -1,5 +1,6 @@
 # This is an API workspace, having public visibility by default makes perfect sense.
 package(default_visibility = ["//visibility:public"])
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 ##############################################################################
 # Common

--- a/google/api/expr/v1alpha1/BUILD.bazel
+++ b/google/api/expr/v1alpha1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "cel_service_proto",

--- a/google/api/expr/v1beta1/BUILD.bazel
+++ b/google/api/expr/v1beta1/BUILD.bazel
@@ -1,5 +1,6 @@
 # This is an API workspace, having public visibility by default makes perfect sense.
 package(default_visibility = ["//visibility:public"])
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "decl_proto",

--- a/google/bigtable/admin/v2/BUILD.bazel
+++ b/google/bigtable/admin/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "bigtableadmin_proto",

--- a/google/bigtable/v2/BUILD.bazel
+++ b/google/bigtable/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "bigtable_proto",

--- a/google/cloud/asset/v1beta1/BUILD.bazel
+++ b/google/cloud/asset/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "asset_proto",

--- a/google/cloud/automl/v1beta1/BUILD.bazel
+++ b/google/cloud/automl/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "automl_proto",

--- a/google/cloud/bigquery/datatransfer/v1/BUILD.bazel
+++ b/google/cloud/bigquery/datatransfer/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "bigquerydatatransfer_proto",

--- a/google/cloud/bigquery/storage/v1beta1/BUILD.bazel
+++ b/google/cloud/bigquery/storage/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "bigquerystorage_proto",

--- a/google/cloud/dataproc/v1/BUILD.bazel
+++ b/google/cloud/dataproc/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "dataproc_proto",

--- a/google/cloud/dataproc/v1beta2/BUILD.bazel
+++ b/google/cloud/dataproc/v1beta2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "dataproc_proto",

--- a/google/cloud/dialogflow/v2/BUILD.bazel
+++ b/google/cloud/dialogflow/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "dialogflow_proto",

--- a/google/cloud/dialogflow/v2beta1/BUILD.bazel
+++ b/google/cloud/dialogflow/v2beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "dialogflow_proto",

--- a/google/cloud/iot/v1/BUILD.bazel
+++ b/google/cloud/iot/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "iot_proto",

--- a/google/cloud/kms/v1/BUILD.bazel
+++ b/google/cloud/kms/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "kms_proto",

--- a/google/cloud/language/v1/BUILD.bazel
+++ b/google/cloud/language/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "language_proto",

--- a/google/cloud/language/v1beta2/BUILD.bazel
+++ b/google/cloud/language/v1beta2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "language_proto",

--- a/google/cloud/oslogin/common/BUILD.bazel
+++ b/google/cloud/oslogin/common/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "common_proto",

--- a/google/cloud/oslogin/v1/BUILD.bazel
+++ b/google/cloud/oslogin/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 _PROTO_SUBPACKAGE_DEPS = [
     "//google/cloud/oslogin/common:common_proto",

--- a/google/cloud/oslogin/v1beta/BUILD.bazel
+++ b/google/cloud/oslogin/v1beta/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 _PROTO_SUBPACKAGE_DEPS = [
     "//google/cloud/oslogin/common:common_proto",

--- a/google/cloud/redis/v1/BUILD.bazel
+++ b/google/cloud/redis/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "redis_proto",

--- a/google/cloud/redis/v1beta1/BUILD.bazel
+++ b/google/cloud/redis/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "redis_proto",

--- a/google/cloud/scheduler/v1beta1/BUILD.bazel
+++ b/google/cloud/scheduler/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "scheduler_proto",

--- a/google/cloud/securitycenter/v1beta1/BUILD.bazel
+++ b/google/cloud/securitycenter/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "securitycenter_proto",

--- a/google/cloud/speech/v1/BUILD.bazel
+++ b/google/cloud/speech/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "speech_proto",

--- a/google/cloud/speech/v1p1beta1/BUILD.bazel
+++ b/google/cloud/speech/v1p1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "speech_proto",

--- a/google/cloud/tasks/v2beta2/BUILD.bazel
+++ b/google/cloud/tasks/v2beta2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "tasks_proto",

--- a/google/cloud/tasks/v2beta3/BUILD.bazel
+++ b/google/cloud/tasks/v2beta3/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "tasks_proto",

--- a/google/cloud/texttospeech/v1/BUILD.bazel
+++ b/google/cloud/texttospeech/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "texttospeech_proto",

--- a/google/cloud/texttospeech/v1beta1/BUILD.bazel
+++ b/google/cloud/texttospeech/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "texttospeech_proto",

--- a/google/cloud/videointelligence/v1/BUILD.bazel
+++ b/google/cloud/videointelligence/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "video_intelligence_proto",

--- a/google/cloud/videointelligence/v1beta1/BUILD.bazel
+++ b/google/cloud/videointelligence/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "video_intelligence_proto",

--- a/google/cloud/videointelligence/v1beta2/BUILD.bazel
+++ b/google/cloud/videointelligence/v1beta2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "video_intelligence_proto",

--- a/google/cloud/videointelligence/v1p1beta1/BUILD.bazel
+++ b/google/cloud/videointelligence/v1p1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "video_intelligence_proto",

--- a/google/cloud/videointelligence/v1p2beta1/BUILD.bazel
+++ b/google/cloud/videointelligence/v1p2beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "video_intelligence_proto",

--- a/google/cloud/videointelligence/v1p3beta1/BUILD.bazel
+++ b/google/cloud/videointelligence/v1p3beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "video_intelligence_proto",

--- a/google/cloud/vision/v1/BUILD.bazel
+++ b/google/cloud/vision/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "vision_proto",

--- a/google/cloud/vision/v1p1beta1/BUILD.bazel
+++ b/google/cloud/vision/v1p1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "vision_proto",

--- a/google/cloud/vision/v1p2beta1/BUILD.bazel
+++ b/google/cloud/vision/v1p2beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "vision_proto",

--- a/google/cloud/vision/v1p3beta1/BUILD.bazel
+++ b/google/cloud/vision/v1p3beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "vision_proto",

--- a/google/cloud/vision/v1p4beta1/BUILD.bazel
+++ b/google/cloud/vision/v1p4beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "vision_proto",

--- a/google/cloud/websecurityscanner/v1alpha/BUILD.bazel
+++ b/google/cloud/websecurityscanner/v1alpha/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "websecurityscanner_proto",

--- a/google/container/v1/BUILD.bazel
+++ b/google/container/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "container_proto",

--- a/google/datastore/v1/BUILD.bazel
+++ b/google/datastore/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "datastore_proto",

--- a/google/devtools/clouddebugger/v2/BUILD.bazel
+++ b/google/devtools/clouddebugger/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "debugger_proto",

--- a/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel
+++ b/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "clouderrorreporting_proto",

--- a/google/devtools/cloudtrace/v1/BUILD.bazel
+++ b/google/devtools/cloudtrace/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "trace_proto",

--- a/google/devtools/cloudtrace/v2/BUILD.bazel
+++ b/google/devtools/cloudtrace/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "trace_proto",

--- a/google/devtools/containeranalysis/v1beta1/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 _PROTO_SUBPACKAGE_DEPS = [
     "//google/devtools/containeranalysis/v1beta1/attestation:attestation_proto",

--- a/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "attestation_proto",

--- a/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "build_proto",

--- a/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "common_proto",

--- a/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "deployment_proto",

--- a/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "discovery_proto",

--- a/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "grafeas_proto",

--- a/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "image_proto",

--- a/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "package_proto",

--- a/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "provenance_proto",

--- a/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "source_proto",

--- a/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel
+++ b/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "vulnerability_proto",

--- a/google/devtools/source/v1/BUILD.bazel
+++ b/google/devtools/source/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "source_proto",

--- a/google/example/library/v1/BUILD.bazel
+++ b/google/example/library/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "library_proto",

--- a/google/firestore/v1beta1/BUILD.bazel
+++ b/google/firestore/v1beta1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "firestore_proto",

--- a/google/iam/admin/v1/BUILD.bazel
+++ b/google/iam/admin/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "iam_admin_proto",

--- a/google/iam/credentials/v1/BUILD.bazel
+++ b/google/iam/credentials/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "iamcredentials_proto",

--- a/google/iam/v1/BUILD.bazel
+++ b/google/iam/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "iam_policy_proto",

--- a/google/iam/v1/logging/BUILD.bazel
+++ b/google/iam/v1/logging/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "audit_data_proto",

--- a/google/logging/type/BUILD.bazel
+++ b/google/logging/type/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "http_request_proto",

--- a/google/logging/v2/BUILD.bazel
+++ b/google/logging/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 _PROTO_SUBPACKAGE_DEPS = [
     "//google/logging/type:http_request_proto",

--- a/google/longrunning/BUILD.bazel
+++ b/google/longrunning/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "operations_proto",

--- a/google/monitoring/v3/BUILD.bazel
+++ b/google/monitoring/v3/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "monitoring_proto",

--- a/google/privacy/dlp/v2/BUILD.bazel
+++ b/google/privacy/dlp/v2/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "dlp_proto",

--- a/google/pubsub/v1/BUILD.bazel
+++ b/google/pubsub/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "pubsub_proto",

--- a/google/rpc/BUILD.bazel
+++ b/google/rpc/BUILD.bazel
@@ -1,5 +1,6 @@
 # This is an API workspace, having public visibility by default makes perfect sense.
 package(default_visibility = ["//visibility:public"])
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 ##############################################################################
 # Common

--- a/google/spanner/admin/database/v1/BUILD.bazel
+++ b/google/spanner/admin/database/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "spanner_admin_database_proto",

--- a/google/spanner/admin/instance/v1/BUILD.bazel
+++ b/google/spanner/admin/instance/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "spanner_admin_instance_proto",

--- a/google/spanner/v1/BUILD.bazel
+++ b/google/spanner/v1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # Common
 ##############################################################################
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "spanner_proto",

--- a/google/type/BUILD.bazel
+++ b/google/type/BUILD.bazel
@@ -1,6 +1,8 @@
 # This is an API workspace, having public visibility by default makes perfect sense.
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 ##############################################################################
 # Common
 ##############################################################################


### PR DESCRIPTION
In a near future, the native proto_library rule will be no longer supported by Bazel.

This pull request suggests a possible migration start to use proto_library rules loaded from https://github.com/bazelbuild/rules_proto