### PR TITLE
Change the min Bazel version to 0.29.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ libraries, documentation, and other artifacts.
 ### Bazel
 
 The recommended way to build the API client libraries is through
-[Bazel](https://bazel.build/) >= 0.23.0.
+[Bazel](https://bazel.build/) >= 0.29.1.
 
 First, [install bazel](https://docs.bazel.build/versions/master/install.html).
 


### PR DESCRIPTION
Since 0.23.0 now breaks on proto_library target, we need to use a higher 
version of Bazel. Right now, 0.29.1 is the latest release.