### PR TITLE
Corrected sample AppResponse link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ change to the API.
 To generate gRPC source code for Google APIs in this repository, you
 first need to install both Protocol Buffers and gRPC on your local
 machine, then you can run `make LANGUAGE=xxx all` to generate the
-source code. You need to integrated the generated source code into
+source code. You need to integrate the generated source code into
 your application build system.
 
 **NOTE:** The Makefile is only intended to generate source code for the

--- a/google/assistant/embedded/v1alpha2/embedded_assistant.proto
+++ b/google/assistant/embedded/v1alpha2/embedded_assistant.proto
@@ -150,7 +150,7 @@ message AssistResponse {
 message DebugInfo {
   // The original JSON response from an Action-on-Google agent to Google server.
   // See
-  // https://developers.google.com/actions/reference/rest/Shared.Types/AppResponse.
+  // https://developers.google.com/actions/reference/rest/Shared.Types/AppResponse
   // It will only be populated if the request maker owns the AoG project and the
   // AoG project is in preview mode.
   string aog_agent_to_assistant_json = 1;


### PR DESCRIPTION
Removed the fullstpp(.) at EOD of line 153 of file google/assistant/embedded/v1alpha2/embedded_assistant.proto