### PR TITLE
fixed yaml: unmarshal errors

### DIFF
--- a/google/cloud/language/v1/samples/language_entity_sentiment_gcs.yaml
+++ b/google/cloud/language/v1/samples/language_entity_sentiment_gcs.yaml
@@ -26,7 +26,7 @@ samples:
     value: UTF8
     comment: "Available values: NONE, UTF8, UTF16, UTF32"
   response:
-  - comment: Loop through entitites returned from the API
+  - comment: ["Loop through entitites returned from the API"]
   - loop:
       collection: $resp.entities
       variable: entity


### PR DESCRIPTION
Running the example protoc command described [here](https://github.com/googleapis/gapic-generator-go/tree/master/cmd/gen-go-sample#invocation) to generate samples for the languages API returns an error: "cannot unmarshal !!str `Loop th...` into []string Sample generation failed.". This fixes it by using a list for comments in the sample config yaml.