### PR TITLE
Add boilerplate required to use python protos when included as an external bazel repo

### DIFF
--- a/google/BUILD.bazel
+++ b/google/BUILD.bazel
@@ -1,0 +1,7 @@
+py_library(
+    name = "python",
+    srcs = [
+        "__init__.py",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,0 +1,4 @@
+try:
+  __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+  __path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Similar to #7 but that solution (based on building sdists) doesn't work when including `googleapis` as an external bazel repo and then using the python proto targets.

In that use case, the protos get generated under `com_google_googleapis/google/api` without an `__init__.py` at the `google` level which conflicts with `com_google_protobuf/python/google/__init__.py`.

Adding a `py_library` target at the `google` level allows consumers to depend on that and the generated `pb2`s which results in an acceptable layout.

That said, I don't know enough about the other ways artifacts are created in the repo to know whether sticking this in at this location might mess up what those build processes generate.