### PR TITLE
bytestream: add BUILD file

### DIFF
--- a/google/bytestream/BUILD.bazel
+++ b/google/bytestream/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility=["//visibility:public"])
+
+proto_library(
+    name="bytestream_proto",
+    srcs=[
+        "bytestream.proto",
+    ],
+    deps = [
+        "//google/api:annotations_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)


### PR DESCRIPTION
Note that the bytestream.proto is before this patch not accessible.