### PR TITLE
chore: add php rules to longrunning

### DIFF
--- a/google/longrunning/BUILD.bazel
+++ b/google/longrunning/BUILD.bazel
@@ -112,3 +112,48 @@ cc_grpc_library(
     grpc_only = True,
     deps = [":longrunning_cc_proto"],
 )
+
+##############################################################################
+# PHP
+##############################################################################
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "php_gapic_assembly_pkg",
+    "php_gapic_library",
+    "php_grpc_library",
+    "php_proto_library",
+)
+
+php_proto_library(
+    name = "longrunning_php_proto",
+    deps = [":operations_proto"],
+)
+
+php_grpc_library(
+    name = "longrunning_php_grpc",
+    srcs = [":operations_proto"],
+    deps = [":longrunning_php_proto"],
+)
+
+php_gapic_library(
+    name = "longrunning_php_gapic",
+    src = ":longrunning_proto_with_info",
+    gapic_yaml = "longrunning_gapic.yaml",
+    grpc_service_config = "longrunning_grpc_service_config.json",
+    service_yaml = "//google/longrunning:longrunning.yaml",
+    package = "google.longrunning",
+    deps = [
+        ":longrunning_php_grpc",
+        ":longrunning_php_proto",
+    ],
+)
+
+# Open Source Packages
+php_gapic_assembly_pkg(
+    name = "google-longrunning-php",
+    deps = [
+        ":longrunning_php_gapic",
+        ":longrunning_php_grpc",
+        ":longrunning_php_proto",
+    ],
+)


### PR DESCRIPTION
In order to update PHP's longrunning GAPIC clients, add BAZEL rules