### PR TITLE
chore: add github action to generate API index

### DIFF
--- a/.github/workflows/generate_api_index.yaml
+++ b/.github/workflows/generate_api_index.yaml
@@ -1,0 +1,29 @@
+name: Generate API Index
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v1.8.0
+      - name: Checkout googleapis (this repository)
+        uses: actions/checkout@v2
+      - name: Checkout index generator
+        uses: actions/checkout@v2
+        with:
+          repository: dwsupplee/googleapis-api-index-generator
+          path: gen
+      - name: Generate API index
+        run: |
+          gen/scripts/generate-schema.sh
+          gen/scripts/generate-index.sh $PWD
+          cp gen/tmp/api-index-v1.json $PWD
+      - name: Commit API index
+        run: |
+          git config user.name "Google APIs"
+          git add api-index-v1.json
+          git commit -m "chore: regenerate API index"
+          git push

--- a/.github/workflows/generate_api_index.yaml
+++ b/.github/workflows/generate_api_index.yaml
@@ -23,6 +23,7 @@ jobs:
           cp gen/tmp/api-index-v1.json $PWD
       - name: Commit API index
         run: |
+          [[ ! $(git diff --exit-code api-index-v1.json) ]] && echo "Nothing to commit." && exit 0
           git config user.name "Google APIs"
           git add api-index-v1.json
           git commit -m "chore: regenerate API index"

--- a/.github/workflows/generate_api_index.yaml
+++ b/.github/workflows/generate_api_index.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout index generator
         uses: actions/checkout@v2
         with:
-          repository: dwsupplee/googleapis-api-index-generator
+          repository: googleapis/googleapis-api-index-generator
           path: gen
       - name: Generate API index
         run: |


### PR DESCRIPTION
This action will regenerate the API index introduced by https://github.com/googleapis/googleapis/pull/646. It is triggered on each commit coming in to master. 

As [the generator](https://github.com/googleapis/googleapis-api-index-generator/) develops we will tag a stable reason and pin to that in this action.
