### PR TITLE
Remove unused imports in logging/v2

### DIFF
--- a/google/logging/v2/log_entry.proto
+++ b/google/logging/v2/log_entry.proto
@@ -24,8 +24,6 @@ import "google/logging/type/log_severity.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "google/rpc/status.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";

--- a/google/logging/v2/logging.proto
+++ b/google/logging/v2/logging.proto
@@ -21,11 +21,8 @@ import "google/api/field_behavior.proto";
 import "google/api/monitored_resource.proto";
 import "google/api/resource.proto";
 import "google/logging/v2/log_entry.proto";
-import "google/logging/v2/logging_config.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/field_mask.proto";
-import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 import "google/api/annotations.proto";
 

--- a/google/logging/v2/logging_config.proto
+++ b/google/logging/v2/logging_config.proto
@@ -19,7 +19,6 @@ package google.logging.v2;
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";

--- a/google/logging/v2/logging_metrics.proto
+++ b/google/logging/v2/logging_metrics.proto
@@ -21,9 +21,7 @@ import "google/api/distribution.proto";
 import "google/api/field_behavior.proto";
 import "google/api/metric.proto";
 import "google/api/resource.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
 import "google/api/annotations.proto";
 


### PR DESCRIPTION
Bazel warns about these unused imports in every build:

    google/logging/v2/log_entry.proto:28:1:       warning: Import google/api/annotations.proto is unused.
    google/logging/v2/log_entry.proto:27:1:       warning: Import google/rpc/status.proto is unused.
    google/logging/v2/logging_config.proto:22:1:  warning: Import google/protobuf/duration.proto is unused.
    google/logging/v2/logging.proto:28:1:         warning: Import google/protobuf/timestamp.proto is unused.
    google/logging/v2/logging.proto:24:1:         warning: Import google/logging/v2/logging_config.proto is unused.
    google/logging/v2/logging.proto:27:1:         warning: Import google/protobuf/field_mask.proto is unused.
    google/logging/v2/logging_metrics.proto:24:1: warning: Import google/protobuf/duration.proto is unused.
    google/logging/v2/logging_metrics.proto:26:1: warning: Import google/protobuf/field_mask.proto is unused.

Looks the majority of imports were added by https://github.com/googleapis/googleapis/commit/2e02174cad304dac67a40e1f63885964c4db91b2.