### PR TITLE
Output file from protoc should be set to service.descriptor

### DIFF
--- a/google/example/endpointsapis/README.md
+++ b/google/example/endpointsapis/README.md
@@ -89,11 +89,11 @@ Run the following commands to generate proto descriptor and push the
 descriptor and service configuration to the Service Management API.
 
 ```shell
-# Generate proto descriptors from the proto files.
+# Generate proto descriptor from the proto files.
 protoc --include_source_info --include_imports --descriptor_set_out=service.descriptor v1/workspace.proto
 
-# Push the proto descriptors and yaml files to the Service Management API.
-gcloud endpoints services deploy service.descriptors endpointsapis.yaml
+# Push the proto descriptor and yaml files to the Service Management API.
+gcloud endpoints services deploy service.descriptor endpointsapis.yaml
 ```
 
 For more information, see

--- a/google/example/endpointsapis/README.md
+++ b/google/example/endpointsapis/README.md
@@ -90,7 +90,7 @@ descriptor and service configuration to the Service Management API.
 
 ```shell
 # Generate proto descriptors from the proto files.
-protoc --include_source_info --include_imports --descriptor_set_out=service.descriptors v1/workspace.proto
+protoc --include_source_info --include_imports --descriptor_set_out=service.descriptor v1/workspace.proto
 
 # Push the proto descriptors and yaml files to the Service Management API.
 gcloud endpoints services deploy service.descriptors endpointsapis.yaml


### PR DESCRIPTION
The README.md file's instructions for running the `protoc` command specify the output service descriptor file name as `service.descriptors`. Since the extension of the filename is neither one of `.pb`, `.descriptor` or `.proto.bin`, the file gets read as a text file instead of a binary file. And because of that, the `gcloud endpoins services deploy` command fails with the following error:

```
'utf-8' codec can't decode byte 0xd7 in position 1: invalid continuation byte
```

This pull request is to change the instructions in the `README.md` file to generate the service descriptor file with the extension as `.descriptor`.