### PR TITLE
update description for name of TransferConfig

### DIFF
--- a/google/cloud/bigquery/datatransfer/v1/transfer.proto
+++ b/google/cloud/bigquery/datatransfer/v1/transfer.proto
@@ -111,12 +111,12 @@ message TransferConfig {
   };
 
   // The resource name of the transfer config.
-  // Transfer config names have the form of
+  // Transfer config names have the form
   // `projects/{project_id}/locations/{region}/transferConfigs/{config_id}`.
   // The name is automatically generated based on the config_id specified in
-  // CreateTransferConfigRequest along with project_id and region. If config_id
-  // is not provided, usually a uuid, even though it is not guaranteed or
-  // required, will be generated for config_id.
+  // CreateTransferConfigRequest along with project_id and region.
+  // Where `config_id` is usually a uuid, even though it is not guaranteed or required.
+  // The name is ignored when creating a transfer config.
   string name = 1;
 
   // The desination of the transfer config.


### PR DESCRIPTION
Update the description to match the official documentation and actual behavior (no way to set config_id on client side)
https://cloud.google.com/bigquery-transfer/docs/reference/datatransfer/rpc/google.cloud.bigquery.datatransfer.v1#transferconfig