### PR TITLE
Remove unused proto google/protobuf/any.proto from cloud_speech.proto

### DIFF
--- a/google/cloud/speech/v1p1beta1/cloud_speech.proto
+++ b/google/cloud/speech/v1p1beta1/cloud_speech.proto
@@ -21,7 +21,6 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/cloud/speech/v1p1beta1/resource.proto";
 import "google/longrunning/operations.proto";
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";


### PR DESCRIPTION
Protoc throws a warning when called against this proto:
google/cloud/speech/v1p1beta1/cloud_speech.proto:24:1: warning: Import google/protobuf/any.proto is unused.

No clear usage inside the proto, so suggest eliding.