### PR TITLE
Remove Unused Proto Imports from cloud/speech/v1p1beta1/resource.proto

### DIFF
--- a/google/cloud/speech/v1p1beta1/resource.proto
+++ b/google/cloud/speech/v1p1beta1/resource.proto
@@ -17,8 +17,6 @@ syntax = "proto3";
 package google.cloud.speech.v1p1beta1;
 
 import "google/api/resource.proto";
-import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/cloud/speech/v1p1beta1;speech";


### PR DESCRIPTION
Note that protoc complains when processing this proto file:

google/cloud/speech/v1p1beta1/resource.proto:21:1: warning: Import google/api/annotations.proto is unused.
google/cloud/speech/v1p1beta1/resource.proto:20:1: warning: Import google/protobuf/timestamp.proto is unused.

These don't appear to be used here, so suggest eliding.