### PR TITLE
chore: Add C# generation for Compute v1

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -427,3 +427,47 @@ ruby_gapic_assembly_pkg(
         ":compute_ruby_proto",
     ],
 )
+
+
+##############################################################################
+# C#
+##############################################################################
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "csharp_gapic_assembly_pkg",
+    "csharp_gapic_library",
+    "csharp_grpc_library",
+    "csharp_proto_library",
+)
+
+csharp_proto_library(
+    name = "compute_csharp_proto",
+    deps = [":compute_proto"],
+)
+
+csharp_grpc_library(
+    name = "compute_csharp_grpc",
+    srcs = [":compute_proto"],
+    deps = [":compute_csharp_proto"],
+)
+
+csharp_gapic_library(
+    name = "compute_csharp_gapic",
+    srcs = [":compute_proto_with_info"],
+    common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
+    grpc_service_config = ":compute_grpc_service_config.json",
+    deps = [
+        ":compute_csharp_grpc",
+        ":compute_csharp_proto",
+    ],
+)
+
+# Open Source Packages
+csharp_gapic_assembly_pkg(
+    name = "google-cloud-compute-v1-csharp",
+    deps = [
+        ":compute_csharp_gapic",
+        ":compute_csharp_grpc",
+        ":compute_csharp_proto",
+    ],
+)


### PR DESCRIPTION
I expect this change will eventually need to be in internal source control, but I'm hoping that creating a PR is the right way forward for now.