### PR TITLE
fix(compute): mark required parent_id fields REQUIRED

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -8919,8 +8919,11 @@ message InsertFirewallPolicyRequest {
   // The body resource for this request
   FirewallPolicy firewall_policy_resource = 495049532 [(google.api.field_behavior) = REQUIRED];
 
-  // Parent ID for this request. The ID can be either be "folders/[FOLDER_ID]" if the parent is a folder or "organizations/[ORGANIZATION_ID]" if the parent is an organization.
-  optional string parent_id = 459714768 [(google.cloud.operation_request_field) = "parent_id"];
+  // Required. Parent ID for this request. The ID can be either be "folders/[FOLDER_ID]" if the parent is a folder or "organizations/[ORGANIZATION_ID]" if the parent is an organization.
+  string parent_id = 459714768 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.cloud.operation_request_field) = "parent_id"
+  ];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
   optional string request_id = 37109963;
@@ -14872,8 +14875,11 @@ message MoveFirewallPolicyRequest {
   // Name of the firewall policy to update.
   string firewall_policy = 498173265 [(google.api.field_behavior) = REQUIRED];
 
-  // The new parent of the firewall policy.
-  optional string parent_id = 459714768 [(google.cloud.operation_request_field) = "parent_id"];
+  // Required. The new parent of the firewall policy.
+  string parent_id = 459714768 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.cloud.operation_request_field) = "parent_id"
+  ];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
   optional string request_id = 37109963;


### PR DESCRIPTION
Mark the required fields `parent_id` in `MoveFirewallPolicyRequest` and `InsertFirewallPolicyRequest` as `REQUIRED`.