### PR TITLE
fix: make parent_id fields required compute move and insert methods

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -8983,7 +8983,10 @@ message InsertFirewallPolicyRequest {
   FirewallPolicy firewall_policy_resource = 495049532 [(google.api.field_behavior) = REQUIRED];
 
   // Parent ID for this request. The ID can be either be "folders/[FOLDER_ID]" if the parent is a folder or "organizations/[ORGANIZATION_ID]" if the parent is an organization.
-  optional string parent_id = 459714768 [(google.cloud.operation_request_field) = "parent_id"];
+  string parent_id = 459714768 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.cloud.operation_request_field) = "parent_id"
+  ];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
   optional string request_id = 37109963;
@@ -14970,7 +14973,10 @@ message MoveFirewallPolicyRequest {
   string firewall_policy = 498173265 [(google.api.field_behavior) = REQUIRED];
 
   // The new parent of the firewall policy.
-  optional string parent_id = 459714768 [(google.cloud.operation_request_field) = "parent_id"];
+  string parent_id = 459714768 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.cloud.operation_request_field) = "parent_id"
+  ];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
   optional string request_id = 37109963;
@@ -26620,7 +26626,7 @@ service FirewallPolicies {
       body: "firewall_policy_resource"
       post: "/compute/v1/locations/global/firewallPolicies"
     };
-    option (google.api.method_signature) = "firewall_policy_resource";
+    option (google.api.method_signature) = "parent_id,firewall_policy_resource";
     option (google.cloud.operation_service) = "GlobalOrganizationOperations";
   }
 
@@ -26645,7 +26651,7 @@ service FirewallPolicies {
     option (google.api.http) = {
       post: "/compute/v1/locations/global/firewallPolicies/{firewall_policy}/move"
     };
-    option (google.api.method_signature) = "firewall_policy";
+    option (google.api.method_signature) = "firewall_policy,parent_id";
     option (google.cloud.operation_service) = "GlobalOrganizationOperations";
   }
 

--- a/google/cloud/compute/v1/compute.v1.json
+++ b/google/cloud/compute/v1/compute.v1.json
@@ -16891,7 +16891,8 @@
         },
         "move": {
           "parameterOrder": [
-            "firewallPolicy"
+            "firewallPolicy",
+            "parentId"
           ],
           "response": {
             "$ref": "Operation"
@@ -16914,7 +16915,8 @@
             "parentId": {
               "type": "string",
               "description": "The new parent of the firewall policy.",
-              "location": "query"
+              "location": "query",
+              "required": true
             },
             "requestId": {
               "description": "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).",
@@ -17265,6 +17267,9 @@
           }
         },
         "insert": {
+          "parameterOrder": [
+            "parentId"
+          ],
           "response": {
             "$ref": "Operation"
           },
@@ -17284,7 +17289,8 @@
             "parentId": {
               "location": "query",
               "description": "Parent ID for this request. The ID can be either be \"folders/[FOLDER_ID]\" if the parent is a folder or \"organizations/[ORGANIZATION_ID]\" if the parent is an organization.",
-              "type": "string"
+              "type": "string",
+              "required": true
             }
           },
           "request": {


### PR DESCRIPTION
Note that the order in `parameterOrder` property in Json file matters and must remain consistent. If we want to flip the order `firewallPolicy` and `parentId` this is the last chance to do so.