### PR TITLE
fix!: handle GCE enum name start with uppercase IPProtocol

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -615,7 +615,7 @@ message Address {
     // VM internal/alias IP, Internal LB service IP, etc.
     GCE_ENDPOINT = 230515243;
 
-    // A regional internal IP address range reserved for the VLAN attachment that is used in IPsec-encrypted Cloud Interconnect. This regional internal IP address range must not overlap with any IP address range of subnet/route in the VPC network and its peering networks. After the VLAN attachment is created with the reserved IP address range, when creating a new VPN gateway, its interface IP address is allocated from the associated VLAN attachment���s IP address range.
+    // A regional internal IP address range reserved for the VLAN attachment that is used in IPsec-encrypted Cloud Interconnect. This regional internal IP address range must not overlap with any IP address range of subnet/route in the VPC network and its peering networks. After the VLAN attachment is created with the reserved IP address range, when creating a new VPN gateway, its interface IP address is allocated from the associated VLAN attachment’s IP address range.
     IPSEC_INTERCONNECT = 340437251;
 
     // External IP automatically reserved for Cloud NAT.
@@ -2402,7 +2402,7 @@ message AutoscalingPolicyScalingSchedule {
   // The start timestamps of time intervals when this scaling schedule is to provide a scaling signal. This field uses the extended cron format (with an optional year field). The expression can describe a single timestamp if the optional year is set, in which case the scaling schedule runs once. The schedule is interpreted with respect to time_zone. This field is required. Note: These timestamps only describe when autoscaler starts providing the scaling signal. The VMs need additional time to become serving.
   optional string schedule = 375820951;
 
-  // The time zone to use when interpreting the schedule. The value of this field must be a time zone name from the tz database: http://en.wikipedia.org/wiki/Tz_database. This field is assigned a default value of ���UTC��� if left empty.
+  // The time zone to use when interpreting the schedule. The value of this field must be a time zone name from the tz database: http://en.wikipedia.org/wiki/Tz_database. This field is assigned a default value of “UTC” if left empty.
   optional string time_zone = 36848094;
 
 }
@@ -6133,9 +6133,9 @@ message FixedOrPercent {
 // Represents a Forwarding Rule resource. Forwarding rule resources in Google Cloud can be either regional or global in scope: * [Global](https://cloud.google.com/compute/docs/reference/rest/v1/globalForwardingRules) * [Regional](https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules) A forwarding rule and its corresponding IP address represent the frontend configuration of a Google Cloud Platform load balancer. Forwarding rules can also reference target instances and Cloud VPN Classic gateways (targetVpnGateway). For more information, read Forwarding rule concepts and Using protocol forwarding.
 message ForwardingRule {
   // The IP protocol to which this rule applies. For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP, ICMP and L3_DEFAULT. The valid IP protocols are different for different load balancing products as described in [Load balancing features](https://cloud.google.com/load-balancing/docs/features#protocols_from_the_load_balancer_to_the_backends).
-  enum IPProtocol {
+  enum IPProtocolEnum {
     // A value indicating that the enum field is not set.
-    UNDEFINED_I_P_PROTOCOL = 0;
+    UNDEFINED_I_P_PROTOCOL_ENUM = 0;
 
     AH = 2087;
 
@@ -6219,7 +6219,7 @@ message ForwardingRule {
   optional string I_p_address = 42976943;
 
   // The IP protocol to which this rule applies. For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP, ICMP and L3_DEFAULT. The valid IP protocols are different for different load balancing products as described in [Load balancing features](https://cloud.google.com/load-balancing/docs/features#protocols_from_the_load_balancer_to_the_backends).
-  // Check the IPProtocol enum for the list of possible values.
+  // Check the IPProtocolEnum enum for the list of possible values.
   optional string I_p_protocol = 488094525;
 
   // This field is used along with the backend_service field for Internal TCP/UDP Load Balancing or Network Load Balancing, or with the target field for internal and external TargetInstance. You can only use one of ports and port_range, or allPorts. The three are mutually exclusive. For TCP, UDP and SCTP traffic, packets addressed to any ports will be forwarded to the target or backendService.
@@ -10613,7 +10613,7 @@ message InstanceGroupManagersAbandonInstancesRequest {
 
 // InstanceGroupManagers.applyUpdatesToInstances
 message InstanceGroupManagersApplyUpdatesRequest {
-  // Flag to update all instances instead of specified list of ���instances���. If the flag is set to true then the instances may not be specified in the request.
+  // Flag to update all instances instead of specified list of “instances”. If the flag is set to true then the instances may not be specified in the request.
   optional bool all_instances = 403676512;
 
   // The list of URLs of one or more instances for which you want to apply updates. Each URL can be a full URL or a partial URL, such as zones/[ZONE]/instances/[INSTANCE_NAME].
@@ -18465,7 +18465,7 @@ message RegionInstanceGroupManagersAbandonInstancesRequest {
 
 // RegionInstanceGroupManagers.applyUpdatesToInstances
 message RegionInstanceGroupManagersApplyUpdatesRequest {
-  // Flag to update all instances instead of specified list of ���instances���. If the flag is set to true then the instances may not be specified in the request.
+  // Flag to update all instances instead of specified list of “instances”. If the flag is set to true then the instances may not be specified in the request.
   optional bool all_instances = 403676512;
 
   // The list of URLs of one or more instances for which you want to apply updates. Each URL can be a full URL or a partial URL, such as zones/[ZONE]/instances/[INSTANCE_NAME].


### PR DESCRIPTION
Note: This is a *BREAKING CHANGE*.

The change is auto generated by latest `disco-to-proto3-converter`. The fix PR: https://github.com/googleapis/disco-to-proto3-converter/pull/62.

Enum type IPProtocol name(start with uppercase not lowercase) cause the protobufjs compiling error with type name duplicate.

To fix it, we need to rename enum name `IPProtocol` to `IPProtocolEnum`. This enum name should not affect other languages. Tested on googleapis/googleapis See googleapis/googleapis#689


Command to update generated compute.proto:
```
$ bazel build //google/cloud/compute/v1:compute_gen
$ cp bazel-bin/google/cloud/compute/v1/compute_gen.proto google/cloud/compute/v1/compute.proto
```