### PR TITLE
fix(compute): replace missing REQUIRED for parent_id

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -9946,7 +9946,10 @@ message InsertFirewallPolicyRequest {
   FirewallPolicy firewall_policy_resource = 495049532 [(google.api.field_behavior) = REQUIRED];
 
   // Parent ID for this request. The ID can be either be "folders/[FOLDER_ID]" if the parent is a folder or "organizations/[ORGANIZATION_ID]" if the parent is an organization.
-  optional string parent_id = 459714768 [(google.cloud.operation_request_field) = "parent_id"];
+  optional string parent_id = 459714768 [
+    (google.cloud.operation_request_field) = "parent_id",
+    (google.api.field_behavior) = REQUIRED
+  ];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
   optional string request_id = 37109963;


### PR DESCRIPTION
The `REQUIRED` field_behavior annotation for `InsertFirewallPolicyRequest.parent_id` (added in https://github.com/googleapis/googleapis/commit/02df998e40733c077aa0fc3f35a6b2d48aa8bf84) was accidentally removed in https://github.com/googleapis/googleapis/commit/249e9a119d24a5cbda66e4f8a2063bf515dae9c0. This caused a backwards incompatible change for the [PHP GAPIC](https://github.com/googleapis/google-cloud-php/pull/5113#discussion_r836958917).

cc: @vchudnov-g 