### PR TITLE
fix(compute): remove proto3_optional from parent_id

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -9946,7 +9946,7 @@ message InsertFirewallPolicyRequest {
   FirewallPolicy firewall_policy_resource = 495049532 [(google.api.field_behavior) = REQUIRED];
 
   // Parent ID for this request. The ID can be either be "folders/[FOLDER_ID]" if the parent is a folder or "organizations/[ORGANIZATION_ID]" if the parent is an organization.
-  optional string parent_id = 459714768 [
+  string parent_id = 459714768 [
     (google.cloud.operation_request_field) = "parent_id",
     (google.api.field_behavior) = REQUIRED
   ];


### PR DESCRIPTION
When I made this field REQUIRED again, I forgot to remove the proto3_optional label as well.