### PR TITLE
feat: Require google-cloud-compute-v1 version 1.3

### DIFF
--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -21,7 +21,7 @@ ruby_cloud_gapic_library(
     srcs = ["//google/cloud/compute/v1:compute_proto_with_info"],
     extra_protoc_parameters = [
         "ruby-cloud-gem-name=google-cloud-compute",
-        "ruby-cloud-wrapper-of=v1:1.1",
+        "ruby-cloud-wrapper-of=v1:1.3",
         "ruby-cloud-product-url=https://cloud.google.com/compute/",
         "ruby-cloud-api-id=compute.googleapis.com",
         "ruby-cloud-api-shortname=compute",


### PR DESCRIPTION
Ensure the Ruby google-cloud-compute wrapper library depends on a new version of compute-v1 that includes the latest service classes.