### PR TITLE
fix(compute): revert proto3_optional, required removal on parent_id

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -16439,7 +16439,10 @@ message MoveFirewallPolicyRequest {
   string firewall_policy = 498173265 [(google.api.field_behavior) = REQUIRED];
 
   // The new parent of the firewall policy.
-  optional string parent_id = 459714768 [(google.cloud.operation_request_field) = "parent_id"];
+  string parent_id = 459714768 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.cloud.operation_request_field) = "parent_id"
+  ];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
   optional string request_id = 37109963;


### PR DESCRIPTION
Fixes accidental breaking change in https://github.com/googleapis/googleapis/commit/249e9a119d24a5cbda66e4f8a2063bf515dae9c0#r71665196.