### PR TITLE
Opt out of REST transport support for Firestore clients.

### DIFF
--- a/google/firestore/admin/v1/BUILD.bazel
+++ b/google/firestore/admin/v1/BUILD.bazel
@@ -82,7 +82,7 @@ java_gapic_library(
     test_deps = [
         ":admin_java_grpc",
     ],
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":admin_java_proto",
         "//google/api:api_java_proto",
@@ -101,7 +101,7 @@ java_gapic_test(
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
     name = "google-cloud-firestore-admin-v1-java",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":admin_java_gapic",
         ":admin_java_grpc",
@@ -140,7 +140,7 @@ go_gapic_library(
     importpath = "cloud.google.com/go/firestore/admin/apiv1;admin",
     metadata = True,
     service_yaml = "firestore_v1.yaml",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":admin_go_proto",
         "//google/longrunning:longrunning_go_proto",

--- a/google/firestore/bundle/BUILD.bazel
+++ b/google/firestore/bundle/BUILD.bazel
@@ -43,7 +43,7 @@ java_proto_library(
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
     name = "google-cloud-firestore-bundle-v1-java",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_bundle_java_proto",
         ":firestore_bundle_proto",

--- a/google/firestore/v1/BUILD.bazel
+++ b/google/firestore/v1/BUILD.bazel
@@ -70,7 +70,7 @@ java_gapic_library(
     test_deps = [
         ":firestore_java_grpc",
     ],
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_java_proto",
     ],
@@ -79,7 +79,6 @@ java_gapic_library(
 java_gapic_test(
     name = "firestore_java_gapic_test_suite",
     test_classes = [
-        "com.google.cloud.firestore.v1.FirestoreClientHttpJsonTest",
         "com.google.cloud.firestore.v1.FirestoreClientTest",
     ],
     runtime_deps = [":firestore_java_gapic_test"],
@@ -88,7 +87,7 @@ java_gapic_test(
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
     name = "google-cloud-firestore-v1-java",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_java_gapic",
         ":firestore_java_grpc",
@@ -126,7 +125,7 @@ go_gapic_library(
     grpc_service_config = "firestore_grpc_service_config.json",
     importpath = "cloud.google.com/go/firestore/apiv1;firestore",
     service_yaml = "//google/firestore:firestore_v1.yaml",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_go_proto",
     ],

--- a/google/firestore/v1beta1/BUILD.bazel
+++ b/google/firestore/v1beta1/BUILD.bazel
@@ -79,7 +79,7 @@ java_gapic_library(
     test_deps = [
         ":firestore_java_grpc",
     ],
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_java_proto",
     ],
@@ -88,7 +88,6 @@ java_gapic_library(
 java_gapic_test(
     name = "firestore_java_gapic_test_suite",
     test_classes = [
-        "com.google.cloud.firestore.v1beta1.FirestoreClientHttpJsonTest",
         "com.google.cloud.firestore.v1beta1.FirestoreClientTest",
     ],
     runtime_deps = [":firestore_java_gapic_test"],
@@ -97,7 +96,7 @@ java_gapic_test(
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
     name = "google-cloud-firestore-v1beta1-java",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_java_gapic",
         ":firestore_java_grpc",
@@ -135,7 +134,7 @@ go_gapic_library(
     grpc_service_config = "firestore_grpc_service_config.json",
     importpath = "cloud.google.com/go/firestore/apiv1beta1;firestore",
     service_yaml = "//google/firestore:firestore_v1beta1.yaml",
-    transport = "grpc+rest",
+    transport = "grpc",
     deps = [
         ":firestore_go_proto",
     ],


### PR DESCRIPTION
Opt out of REST transport support for Firestore clients. Firestore wants to re-visit REST support in the future when we have time to review, test, and release it. Currently we need to opt out to unblock some other work.