### PR TITLE
Revert "chore: Specify rest transport for C# Compute GAPIC (#730)"

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -393,7 +393,6 @@ csharp_gapic_library(
     srcs = [":compute_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = ":compute_grpc_service_config.json",
-    transport = "rest",
     deps = [
         ":compute_csharp_grpc",
         ":compute_csharp_proto",


### PR DESCRIPTION
This reverts commit b1f76aafc3f1ffdfbcf42b12ea1afeb6baf9c34d.