### PR TITLE
chore: Specify the rest transport for C# (again)

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -393,6 +393,7 @@ csharp_gapic_library(
     srcs = [":compute_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = ":compute_grpc_service_config.json",
+    transport = "rest",
     deps = [
         ":compute_csharp_grpc",
         ":compute_csharp_proto",


### PR DESCRIPTION
(Last time it broke as the generator Bazel rules weren't ready. This
time they are.)