### PR TITLE
Clarify the default for task_count_per_node

### DIFF
--- a/google/cloud/batch/v1/job.proto
+++ b/google/cloud/batch/v1/job.proto
@@ -430,8 +430,7 @@ message TaskGroup {
   repeated Environment task_environments = 9;
 
   // Max number of tasks that can be run on a VM at the same time.
-  // If not specified, the system will decide a value based on available
-  // compute resources on a VM and task requirements.
+  // Defaults to 1 if not specified.
   int64 task_count_per_node = 10;
 
   // When true, Batch will populate a file with a list of all VMs assigned to


### PR DESCRIPTION
As per the discussion with @soj-hub, Batch actually defaults to 1 task per VM instead of using some heurtistic for packing multiple tasks on a VM. This clarifies the comment on the proto.