### PR TITLE
fix: remove previous_proto from compute/v1/BUILD.bazel

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -42,7 +42,6 @@ _SERVICE_IGNORELIST = [
 proto_from_disco(
     name = "compute_gen",
     src = "compute.v1.json",
-    previous_proto = "compute.proto",
     enums_as_strings = True,
     message_ignorelist = _MESSAGE_IGNORE_LIST,
     service_ignorelist = _SERVICE_IGNORELIST,
@@ -51,7 +50,6 @@ proto_from_disco(
 grpc_service_config_from_disco(
     name = "compute_grpc_service_config_gen",
     src = "compute.v1.json",
-    previous_proto = "compute.proto",
     message_ignorelist = _MESSAGE_IGNORE_LIST,
     service_ignorelist = _SERVICE_IGNORELIST,
 )
@@ -59,7 +57,6 @@ grpc_service_config_from_disco(
 gapic_yaml_from_disco(
     name = "compute_gapic_gen",
     src = "compute.v1.json",
-    previous_proto = "compute.proto",
     message_ignorelist = _MESSAGE_IGNORE_LIST,
     service_ignorelist = _SERVICE_IGNORELIST,
 )


### PR DESCRIPTION
This fixes an issue where `compute.proto` was not being updated properly. Fixes b/253544291 where `md5AuthenticationKeyName` was not present in `compute.proto`