### PR TITLE
chore: Update Compute BUILD file to specify service config for C#

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -393,6 +393,7 @@ csharp_gapic_library(
     srcs = [":compute_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = ":compute_grpc_service_config.json",
+    service_yaml = "compute_v1.yaml",
     transport = "rest",
     deps = [
         ":compute_csharp_grpc",


### PR DESCRIPTION
This is what's already specified when generating locally, so should be a no-op.