### PR TITLE
feat(compute)!: Calling an RPC with a block yields a TransportOperation rather than a Faraday object

### DIFF
--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -21,7 +21,7 @@ ruby_cloud_gapic_library(
     srcs = ["//google/cloud/compute/v1:compute_proto_with_info"],
     extra_protoc_parameters = [
         "ruby-cloud-gem-name=google-cloud-compute",
-        "ruby-cloud-wrapper-of=v1:1.9",
+        "ruby-cloud-wrapper-of=v1:2.0",
         "ruby-cloud-product-url=https://cloud.google.com/compute/",
         "ruby-cloud-api-id=compute.googleapis.com",
         "ruby-cloud-api-shortname=compute",


### PR DESCRIPTION
Updates the compute wrapper's dependencies to bring in version 2.0 of the gapic.