### PR TITLE
Fix Cloud Vision Go package path

### DIFF
--- a/google/cloud/vision/v1/geometry.proto
+++ b/google/cloud/vision/v1/geometry.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package google.cloud.vision.v1;
 
 option cc_enable_arenas = true;
-option go_package = "cloud.google.com/go/vision/apiv1/visionpb;visionpb";
+option go_package = "cloud.google.com/go/vision/v2/apiv1/visionpb;visionpb";
 option java_multiple_files = true;
 option java_outer_classname = "GeometryProto";
 option java_package = "com.google.cloud.vision.v1";

--- a/google/cloud/vision/v1/image_annotator.proto
+++ b/google/cloud/vision/v1/image_annotator.proto
@@ -30,7 +30,7 @@ import "google/type/color.proto";
 import "google/type/latlng.proto";
 
 option cc_enable_arenas = true;
-option go_package = "cloud.google.com/go/vision/apiv1/visionpb;visionpb";
+option go_package = "cloud.google.com/go/vision/v2/apiv1/visionpb;visionpb";
 option java_multiple_files = true;
 option java_outer_classname = "ImageAnnotatorProto";
 option java_package = "com.google.cloud.vision.v1";

--- a/google/cloud/vision/v1/product_search.proto
+++ b/google/cloud/vision/v1/product_search.proto
@@ -22,7 +22,7 @@ import "google/cloud/vision/v1/product_search_service.proto";
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
-option go_package = "cloud.google.com/go/vision/apiv1/visionpb;visionpb";
+option go_package = "cloud.google.com/go/vision/v2/apiv1/visionpb;visionpb";
 option java_multiple_files = true;
 option java_outer_classname = "ProductSearchProto";
 option java_package = "com.google.cloud.vision.v1";

--- a/google/cloud/vision/v1/product_search_service.proto
+++ b/google/cloud/vision/v1/product_search_service.proto
@@ -28,7 +28,7 @@ import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 option cc_enable_arenas = true;
-option go_package = "cloud.google.com/go/vision/apiv1/visionpb;visionpb";
+option go_package = "cloud.google.com/go/vision/v2/apiv1/visionpb;visionpb";
 option java_multiple_files = true;
 option java_outer_classname = "ProductSearchServiceProto";
 option java_package = "com.google.cloud.vision.v1";

--- a/google/cloud/vision/v1/text_annotation.proto
+++ b/google/cloud/vision/v1/text_annotation.proto
@@ -19,7 +19,7 @@ package google.cloud.vision.v1;
 import "google/cloud/vision/v1/geometry.proto";
 
 option cc_enable_arenas = true;
-option go_package = "cloud.google.com/go/vision/apiv1/visionpb;visionpb";
+option go_package = "cloud.google.com/go/vision/v2/apiv1/visionpb;visionpb";
 option java_multiple_files = true;
 option java_outer_classname = "TextAnnotationProto";
 option java_package = "com.google.cloud.vision.v1";

--- a/google/cloud/vision/v1/web_detection.proto
+++ b/google/cloud/vision/v1/web_detection.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package google.cloud.vision.v1;
 
 option cc_enable_arenas = true;
-option go_package = "cloud.google.com/go/vision/apiv1/visionpb;visionpb";
+option go_package = "cloud.google.com/go/vision/v2/apiv1/visionpb;visionpb";
 option java_multiple_files = true;
 option java_outer_classname = "WebDetectionProto";
 option java_package = "com.google.cloud.vision.v1";


### PR DESCRIPTION
I know this PR probably won't be accepted directly, but I can't figure out a better way to surface this issue.

The current Go package path for the `google.cloud.vision.v1` Protobuf definitions is incorrect. `cloud.google.com/go/vision/apiv1/visionpb` does not exist as a Go module. When published to `googleapis/google-cloud-go`, a `v2/` path segment is added (I believe this occurred in this pull request: https://github.com/googleapis/google-cloud-go/pull/6072). This complicates depending on this Protobuf definition because the generated Go code will be incorrect unless the Go package dependency is overridden out-of-band.

Maybe @quartzmo can look at this as the original author.