### PR TITLE
chore(ci): Upgrade to non-deprecated runtimes in actions

### DIFF
--- a/.github/workflows/generate_api_index.yaml
+++ b/.github/workflows/generate_api_index.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.8.0
+      uses: actions/setup-dotnet@v3
     - name: Checkout googleapis (this repository)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: googleapis
     - name: Checkout index generator
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: googleapis/googleapis-api-index-generator
         path: gen


### PR DESCRIPTION
Hi!

The workflow that generates the API index is using a deprecated Node.js 12 runtime. Github have announced that everyone should move away from the deprecated Node.js runtime as of [this](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) blogpost. 