### PR TITLE
chore: do not run regenerate action on forks

### DIFF
--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -7,6 +7,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   regenerate-compute:
+    if: github.repository == "googleapis/googleapis"
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis:20230301
     steps:


### PR DESCRIPTION
Related links:

https://github.com/orgs/community/discussions/26409

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif

I just hope it will work :)