### PR TITLE
chore: add Go build targets for compute

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ http_archive(
     urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],
 )
 
-# This must be above the download of gRPC (in C++ section) and
+# This must be above the download of gRPC (in C++ section) and 
 # rules_gapic_repositories because both depend on rules_go and we need to manage
 # our version of rules_go explicitly rather than depend on the version those
 # bring in transitively.
@@ -276,7 +276,7 @@ maven_install(
     repositories = [
         "m2Local",
         "https://repo.maven.apache.org/maven2/",
-    ],
+    ]
 )
 
 http_archive(
@@ -352,39 +352,32 @@ http_archive(
     urls = ["https://github.com/googleapis/gapic-generator-typescript/archive/v%s.tar.gz" % _gapic_generator_typescript_version],
 )
 
-load("@gapic_generator_typescript//:repositories.bzl", "NODE_VERSION", "gapic_generator_typescript_repositories")
-
+load("@gapic_generator_typescript//:repositories.bzl", "gapic_generator_typescript_repositories", "NODE_VERSION")
 gapic_generator_typescript_repositories()
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
-
 rules_js_dependencies()
 
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
-
 rules_ts_dependencies(
     ts_version_from = "@gapic_generator_typescript//:package.json",
 )
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
-
 nodejs_register_toolchains(
-    name = "nodejs",
-    node_version = NODE_VERSION,
+  name = "nodejs",
+  node_version = NODE_VERSION,
 )
 
 load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock", "pnpm_repository")
-
 npm_translate_lock(
-    name = "npm",
-    data = ["@gapic_generator_typescript//:package.json"],
-    pnpm_lock = "@gapic_generator_typescript//:pnpm-lock.yaml",
+  name = "npm",
+  pnpm_lock = "@gapic_generator_typescript//:pnpm-lock.yaml",
+  data = ["@gapic_generator_typescript//:package.json"],
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")
-
 npm_repositories()
-
 pnpm_repository(name = "pnpm")
 
 ##############################################################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ http_archive(
     urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],
 )
 
-# This must be above the download of gRPC (in C++ section) and 
+# This must be above the download of gRPC (in C++ section) and
 # rules_gapic_repositories because both depend on rules_go and we need to manage
 # our version of rules_go explicitly rather than depend on the version those
 # bring in transitively.
@@ -276,7 +276,7 @@ maven_install(
     repositories = [
         "m2Local",
         "https://repo.maven.apache.org/maven2/",
-    ]
+    ],
 )
 
 http_archive(
@@ -352,32 +352,39 @@ http_archive(
     urls = ["https://github.com/googleapis/gapic-generator-typescript/archive/v%s.tar.gz" % _gapic_generator_typescript_version],
 )
 
-load("@gapic_generator_typescript//:repositories.bzl", "gapic_generator_typescript_repositories", "NODE_VERSION")
+load("@gapic_generator_typescript//:repositories.bzl", "NODE_VERSION", "gapic_generator_typescript_repositories")
+
 gapic_generator_typescript_repositories()
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
 rules_js_dependencies()
 
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
+
 rules_ts_dependencies(
     ts_version_from = "@gapic_generator_typescript//:package.json",
 )
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
+
 nodejs_register_toolchains(
-  name = "nodejs",
-  node_version = NODE_VERSION,
+    name = "nodejs",
+    node_version = NODE_VERSION,
 )
 
 load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock", "pnpm_repository")
+
 npm_translate_lock(
-  name = "npm",
-  pnpm_lock = "@gapic_generator_typescript//:pnpm-lock.yaml",
-  data = ["@gapic_generator_typescript//:package.json"],
+    name = "npm",
+    data = ["@gapic_generator_typescript//:package.json"],
+    pnpm_lock = "@gapic_generator_typescript//:pnpm-lock.yaml",
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")
+
 npm_repositories()
+
 pnpm_repository(name = "pnpm")
 
 ##############################################################################
@@ -464,7 +471,7 @@ gapic_generator_ruby_repositories()
 # Discovery
 ##############################################################################
 
-_disco_to_proto3_converter_version = "c47a76dd3d591478dd1a902413636c06da1153b8"
+_disco_to_proto3_converter_version = "96e1e63d3c1ddc546a57ac78b28893ee1013266a"
 
 http_archive(
     name = "com_google_disco_to_proto3_converter",

--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -42,25 +42,25 @@ _SERVICE_IGNORELIST = [
 proto_from_disco(
     name = "compute_gen",
     src = "compute.v1.json",
-    previous_proto = "compute.proto",
     enums_as_strings = True,
     message_ignorelist = _MESSAGE_IGNORE_LIST,
+    previous_proto = "compute.proto",
     service_ignorelist = _SERVICE_IGNORELIST,
 )
 
 grpc_service_config_from_disco(
     name = "compute_grpc_service_config_gen",
     src = "compute.v1.json",
-    previous_proto = "compute.proto",
     message_ignorelist = _MESSAGE_IGNORE_LIST,
+    previous_proto = "compute.proto",
     service_ignorelist = _SERVICE_IGNORELIST,
 )
 
 gapic_yaml_from_disco(
     name = "compute_gapic_gen",
     src = "compute.v1.json",
-    previous_proto = "compute.proto",
     message_ignorelist = _MESSAGE_IGNORE_LIST,
+    previous_proto = "compute.proto",
     service_ignorelist = _SERVICE_IGNORELIST,
 )
 
@@ -308,8 +308,8 @@ nodejs_gapic_library(
     name = "compute_nodejs_gapic",
     package_name = "@google-cloud/compute",
     src = ":compute_proto_with_info",
-    extra_protoc_parameters = ["metadata"],
     diregapic = True,
+    extra_protoc_parameters = ["metadata"],
     deps = [],
 )
 
@@ -366,7 +366,6 @@ ruby_gapic_assembly_pkg(
     ],
 )
 
-
 ##############################################################################
 # C#
 ##############################################################################
@@ -409,5 +408,53 @@ csharp_gapic_assembly_pkg(
         ":compute_csharp_gapic",
         ":compute_csharp_grpc",
         ":compute_csharp_proto",
+    ],
+)
+
+##############################################################################
+# Go
+##############################################################################
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "go_gapic_assembly_pkg",
+    "go_gapic_library",
+    "go_proto_library",
+)
+
+go_proto_library(
+    name = "compute_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "cloud.google.com/go/compute/apiv1/computepb",
+    protos = [":compute_proto"],
+    deps = [
+        "//google/api:annotations_go_proto",
+        "//google/cloud:extended_operations_go_proto",
+    ],
+)
+
+go_gapic_library(
+    name = "compute_go_gapic",
+    srcs = [":compute_proto_with_info"],
+    grpc_service_config = "compute_grpc_service_config.json",
+    importpath = "cloud.google.com/go/compute/apiv1;compute",
+    metadata = True,
+    release_level = "ga",
+    rest_numeric_enums = False,
+    service_yaml = "compute_v1.yaml",
+    transport = "rest",
+    deps = [
+        ":compute_go_proto",
+        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
+    ],
+)
+
+# Open Source Packages
+go_gapic_assembly_pkg(
+    name = "gapi-cloud-compute-v1-go",
+    deps = [
+        ":compute_go_gapic",
+        ":compute_go_gapic_srcjar-metadata.srcjar",
+        ":compute_go_gapic_srcjar-test.srcjar",
+        ":compute_go_proto",
     ],
 )

--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -32,7 +32,7 @@ import "google/cloud/extended_operations.proto";
 // File Options
 //
 option csharp_namespace = "Google.Cloud.Compute.V1";
-option go_package = "google.golang.org/genproto/googleapis/cloud/compute/v1;compute";
+option go_package = "cloud.google.com/go/compute/apiv1/computepb";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.compute.v1";
 option php_namespace = "Google\\Cloud\\Compute\\V1";


### PR DESCRIPTION
Note: manually updated proto file, but it yields the same result of the new disco-converter would generate.

Fixes: https://github.com/googleapis/google-cloud-go/issues/7345