### PR TITLE
chore: reenable Go compute targets

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -414,48 +414,48 @@ csharp_gapic_assembly_pkg(
 ##############################################################################
 # Go
 ##############################################################################
-# load(
-#     "@com_google_googleapis_imports//:imports.bzl",
-#     "go_gapic_assembly_pkg",
-#     "go_gapic_library",
-#     "go_proto_library",
-# )
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "go_gapic_assembly_pkg",
+    "go_gapic_library",
+    "go_proto_library",
+)
 
-# go_proto_library(
-#     name = "compute_go_proto",
-#     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-#     importpath = "cloud.google.com/go/compute/apiv1/computepb",
-#     protos = [":compute_proto"],
-#     deps = [
-#         "//google/api:annotations_go_proto",
-#         "//google/cloud:extended_operations_go_proto",
-#     ],
-# )
+go_proto_library(
+    name = "compute_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "cloud.google.com/go/compute/apiv1/computepb",
+    protos = [":compute_proto"],
+    deps = [
+        "//google/api:annotations_go_proto",
+        "//google/cloud:extended_operations_go_proto",
+    ],
+)
 
-# go_gapic_library(
-#     name = "compute_go_gapic",
-#     srcs = [":compute_proto_with_info"],
-#     diregapic = True,
-#     grpc_service_config = "compute_grpc_service_config.json",
-#     importpath = "cloud.google.com/go/compute/apiv1;compute",
-#     metadata = True,
-#     release_level = "ga",
-#     rest_numeric_enums = False,
-#     service_yaml = "compute_v1.yaml",
-#     transport = "rest",
-#     deps = [
-#         ":compute_go_proto",
-#         "@io_bazel_rules_go//proto/wkt:duration_go_proto",
-#     ],
-# )
+go_gapic_library(
+    name = "compute_go_gapic",
+    srcs = [":compute_proto_with_info"],
+    diregapic = True,
+    grpc_service_config = "compute_grpc_service_config.json",
+    importpath = "cloud.google.com/go/compute/apiv1;compute",
+    metadata = True,
+    release_level = "ga",
+    rest_numeric_enums = False,
+    service_yaml = "compute_v1.yaml",
+    transport = "rest",
+    deps = [
+        ":compute_go_proto",
+        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
+    ],
+)
 
-# # Open Source Packages
-# go_gapic_assembly_pkg(
-#     name = "gapi-cloud-compute-v1-go",
-#     deps = [
-#         ":compute_go_gapic",
-#         ":compute_go_gapic_srcjar-metadata.srcjar",
-#         ":compute_go_gapic_srcjar-test.srcjar",
-#         ":compute_go_proto",
-#     ],
-# )
+# Open Source Packages
+go_gapic_assembly_pkg(
+    name = "gapi-cloud-compute-v1-go",
+    deps = [
+        ":compute_go_gapic",
+        ":compute_go_gapic_srcjar-metadata.srcjar",
+        ":compute_go_gapic_srcjar-test.srcjar",
+        ":compute_go_proto",
+    ],
+)


### PR DESCRIPTION
Followup to #794 now that the Go generator has been patched