### PR TITLE
docs: replace invalid example bazel command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bazel build //google/example/library/v1/...
 To build the Java package for one library:
 
 ```
-bazel build //google/example/library/v1:google-cloud-library-v1-java
+bazel build //google/example/library/v1:google-cloud-example-library-v1-java
 ```
 
 Bazel packages exist in all the libraries for Java, Go, Python, Ruby, Node.js, PHP and C#.


### PR DESCRIPTION
The example Bazel command in the README points to a target that does not exist.

```
$ bazel build //google/example/library/v1:google-cloud-library-v1-java
ERROR: Skipping '//google/example/library/v1:google-cloud-library-v1-java': no such target '//google/example/library/v1:google-cloud-library-v1-java': target 'google-cloud-library-v1-java' not declared in package 'google/example/library/v1' defined by /usr/local/google/home/mattlui/github/googleapis/google/example/library/v1/BUILD.bazel (Tip: use `query "//google/example/library/v1:*"` to see all the targets in that package)
WARNING: Target pattern parsing failed.
ERROR: no such target '//google/example/library/v1:google-cloud-library-v1-java': target 'google-cloud-library-v1-java' not declared in package 'google/example/library/v1' defined by /usr/local/google/home/mattlui/github/googleapis/google/example/library/v1/BUILD.bazel (Tip: use `query "//google/example/library/v1:*"` to see all the targets in that package)
INFO: Elapsed time: 0.144s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```

See [google/example/library/v1/BUILD.bazel:113](https://github.com/googleapis/googleapis/blob/master/google/example/library/v1/BUILD.bazel#L113).

Change it to one that does.