### PR TITLE
feat: Adding proto_library for bytestream

### DIFF
--- a/google/bytestream/BUILD.bazel
+++ b/google/bytestream/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "bytestream_proto",
+    srcs = ["bytestream.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//google/api:annotations_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)


### PR DESCRIPTION
Adding proto_library for bytestream so people can import the proto