### PR TITLE
fix(firestore): add missing close quote

### DIFF
--- a/google/firestore/admin/v1/firestore_admin.proto
+++ b/google/firestore/admin/v1/firestore_admin.proto
@@ -164,7 +164,7 @@ service FirestoreAdmin {
   // only supports listing fields that have been explicitly overridden. To issue
   // this query, call
   // [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields]
-  // with the filter set to `indexConfig.usesAncestorConfig:false or
+  // with the filter set to `indexConfig.usesAncestorConfig:false` or
   // `ttlConfig:*`.
   rpc ListFields(ListFieldsRequest) returns (ListFieldsResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
The python-firestore client is currently [failing its docs check](https://github.com/googleapis/python-firestore/actions/runs/7494284636/job/20401853398?pr=826) when attempting to [pull in the latest proto changes](https://github.com/googleapis/python-firestore/pull/826). This can be traced back to the missing ` in this docstring