### PR TITLE
build: add dependencies to nodejs_gapic_assembly_pkg target

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -319,6 +319,7 @@ nodejs_gapic_assembly_pkg(
     deps = [
         ":compute_nodejs_gapic",
         ":compute_proto",
+        "@com_google_googleapis//google/cloud:extended_operations_proto",
     ],
 )
 

--- a/google/cloud/compute/v1small/BUILD.bazel
+++ b/google/cloud/compute/v1small/BUILD.bazel
@@ -169,6 +169,7 @@ nodejs_gapic_assembly_pkg(
     deps = [
         ":compute_small_nodejs_gapic",
         ":compute_small_proto",
+        "@com_google_googleapis//google/cloud:extended_operations_proto",
     ],
 )
 


### PR DESCRIPTION
This is one place that we missed because it's source of truth is right here.