### PR TITLE
feat: Updated dependency on google-cloud-compute-v1 to the latest version

### DIFF
--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -21,7 +21,7 @@ ruby_cloud_gapic_library(
     srcs = ["//google/cloud/compute/v1:compute_proto_with_info"],
     extra_protoc_parameters = [
         "ruby-cloud-gem-name=google-cloud-compute",
-        "ruby-cloud-wrapper-of=v1:2.7",
+        "ruby-cloud-wrapper-of=v1:2.10",
         "ruby-cloud-product-url=https://cloud.google.com/compute/",
         "ruby-cloud-api-id=compute.googleapis.com",
         "ruby-cloud-api-shortname=compute",


### PR DESCRIPTION
For the Ruby wrapper client for compute
