### PR TITLE
feat(bazel): make googleapis a Bzlmod module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ google/protobuf
 .project
 artman-genfiles/
 bazel-*
+MODULE.bazel.lock

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -10,5 +10,11 @@ CACHE_CMDLINE="--remote_cache=https://storage.googleapis.com/${CACHE_BUCKET} --g
 #
 # Run build and tests
 #
+echo "Building and Testing using WORKSPACE dependencies"
 ${BAZELISK_BIN} --output_user_root=${BAZEL_ROOT} build ${CACHE_CMDLINE} --keep_going //...
 ${BAZELISK_BIN} --output_user_root=${BAZEL_ROOT} test ${CACHE_CMDLINE} --flaky_test_attempts=3 --keep_going //...
+
+# Restart the Bazel server to prevent sandbox issues.
+echo "Building and Testing using Bzlmod dependencies"
+${BAZELISK_BIN} shutdown
+${BAZELISK_BIN} --output_user_root=${BAZEL_ROOT} build ${CACHE_CMDLINE} --keep_going --enable_bzlmod //...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,16 +1,29 @@
 module(
-    name = "com_google_googleapis",
-    version = "0.0.0",
+    name = "googleapis",
+    version = "0",
+    repo_name = "com_google_googleapis",
 )
 
+bazel_dep(name = "grpc", version = "1.56.3.bcr.1", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java")
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_go", version = "0.46.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+bazel_dep(name = "rules_python", version = "0.31.0")
 
 switched_rules = use_extension("//:extensions.bzl", "switched_rules")
+
+# TODO: Enable support for other languages with bzlmod
 switched_rules.use_languages(
     cc = True,
+    # csharp = True,
+    # gapic = True,
     go = True,
+    grpc = True,
     java = True,
+    # nodejs = True,
+    # php = True,
     python = True,
+    # ruby = True,
 )
 use_repo(switched_rules, "com_google_googleapis_imports")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,16 @@
+module(
+    name = "com_google_googleapis",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+
+switched_rules = use_extension("//:extensions.bzl", "switched_rules")
+switched_rules.use_languages(
+    cc = True,
+    go = True,
+    java = True,
+    python = True,
+)
+use_repo(switched_rules, "com_google_googleapis_imports")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "grpc", version = "1.56.3.bcr.1", repo_name = "com_github_grpc_grpc")
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java")
+bazel_dep(name = "grpc-java", version = "1.62.2", repo_name = "io_grpc_grpc_java")
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.46.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When Bzlmod is enabled, this file replaces the content of the original WORKSPACE
+# and makes sure no WORKSPACE prefix or suffix are added when Bzlmod is enabled.

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,2 +1,23 @@
 # When Bzlmod is enabled, this file replaces the content of the original WORKSPACE
 # and makes sure no WORKSPACE prefix or suffix are added when Bzlmod is enabled.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+_disco_to_proto3_converter_version = "74c0ede1e6871c878de6c3cab3ef152280c6518f"
+
+http_archive(
+    name = "com_google_disco_to_proto3_converter",
+    strip_prefix = "disco-to-proto3-converter-%s" % _disco_to_proto3_converter_version,
+    urls = ["https://github.com/googleapis/disco-to-proto3-converter/archive/%s.zip" % _disco_to_proto3_converter_version],
+)
+
+load("@com_google_disco_to_proto3_converter//:repository_rules.bzl", "com_google_disco_to_proto3_converter_properties")
+
+com_google_disco_to_proto3_converter_properties(
+    name = "com_google_disco_to_proto3_converter_properties",
+    file = "@com_google_disco_to_proto3_converter//:pom.xml",
+)
+
+load("@com_google_disco_to_proto3_converter//:repositories.bzl", "com_google_disco_to_proto3_converter_repositories")
+
+com_google_disco_to_proto3_converter_repositories()

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -27,10 +27,10 @@ def _switched_rules_impl(ctx):
 
         for t in module.tags.use_languages:
             if is_tag_set:
-                fail("Multiple use_language tags are set in the root module: '{}' and '{}'. Only one is allowed.".format(set_tag_name, t.name))
+                fail("Multiple use_language tags are set in the root module: '{}' and '{}'. Only one is allowed.".format(set_tag_name, module.name))
 
             is_tag_set = True
-            set_tag_name = t.name
+            set_tag_name = module.name
 
             attrs = {
                 "cc": t.cc,

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,0 +1,59 @@
+load(":repository_rules.bzl", "switched_rules_by_language")
+
+_use_languages_tag = tag_class(
+    attrs = {
+        "cc": attr.bool(default = False),
+        "csharp": attr.bool(default = False),
+        "gapic": attr.bool(default = False),
+        "go": attr.bool(default = False),
+        "go_test": attr.bool(default = False),
+        "grpc": attr.bool(default = False),
+        "java": attr.bool(default = False),
+        "nodejs": attr.bool(default = False),
+        "php": attr.bool(default = False),
+        "python": attr.bool(default = False),
+        "ruby": attr.bool(default = False),
+    },
+)
+
+def _switched_rules_impl(ctx):
+    attrs = {}
+    for module in ctx.modules:
+        if not module.is_root:
+            continue
+
+        is_tag_set = False
+        set_tag_name = ""
+
+        for t in module.tags.use_languages:
+            if is_tag_set:
+                fail("Multiple use_language tags are set in the root module: '{}' and '{}'. Only one is allowed.".format(set_tag_name, t.name))
+
+            is_tag_set = True
+            set_tag_name = t.name
+
+            attrs = {
+                "cc": t.cc,
+                "csharp": t.csharp,
+                "gapic": t.gapic,
+                "go": t.go,
+                "go_test": t.go_test,
+                "grpc": t.grpc,
+                "java": t.java,
+                "nodejs": t.nodejs,
+                "php": t.php,
+                "python": t.python,
+                "ruby": t.ruby,
+            }
+
+    switched_rules_by_language(
+        name = "com_google_googleapis_imports",
+        **attrs
+    )
+
+switched_rules = module_extension(
+    implementation = _switched_rules_impl,
+    tag_classes = {
+        "use_languages": _use_languages_tag,
+    },
+)


### PR DESCRIPTION
This depends on https://github.com/bazelbuild/bazel-central-registry/pull/1699 because of a circular dependency on grpc-java

This is based on https://github.com/googleapis/googleapis/pull/855 with some fixes