### PR TITLE
chore: fetch GCE Discovery  doc from discovery-artifact-manager

### DIFF
--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -17,7 +17,7 @@ jobs:
         ref: master
     - name: Download discovery docs
       run: |
-        curl https://www.googleapis.com/discovery/v1/apis/compute/v1/rest --output google/cloud/compute/v1/compute.v1.json
+        curl https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/refs/heads/master/discoveries/compute.v1.json --output google/cloud/compute/v1/compute.v1.json
         echo compute_revision=$(grep -oP '"revision":\s*"\d+"' google/cloud/compute/v1/compute.v1.json | grep -oP '\d+') >> $GITHUB_ENV
     - name: Regenerate API definitions
       run: |


### PR DESCRIPTION
We want to fetch the Discovery file from the discovery-artifact-manager repo, where it is stored in a more canonical form.