### PR TITLE
fix: reduce size of Go compute package

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -425,7 +425,6 @@ load(
 
 go_proto_library(
     name = "compute_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "cloud.google.com/go/compute/apiv1/computepb",
     protos = [":compute_proto"],
     deps = [


### PR DESCRIPTION
Remove the gRPC binding for generated compute protos as they are not valid. This reduces the LoC in this package by ~13%.

Internal Bug: 347305192