### PR TITLE
chore(php): set Compute migration_mode to MIGRATING

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -281,7 +281,7 @@ php_gapic_library(
     grpc_service_config = "compute_grpc_service_config.json",
     service_yaml = "compute_v1.yaml",
     transport = "rest",
-    migration_mode = "MIGRATION_MODE_UNSPECIFIED",
+    migration_mode = "MIGRATING",
     deps = [
         ":compute_php_proto",
     ],


### PR DESCRIPTION
All other `BUILD` files for PHP have long since been updated with `migration_mode=MIGRATING` or even `migration_mode=NEW_SURFACE_ONLY`, but this one was missed because it's canonical source is here (I would suggest that it should be in `third_party` with the rest of the APIs, so that this is less likely to happen). 

We want to move the compute library for PHP to `NEW_SURFACE_ONLY`, but I'd like to create at least one release of the compute library with the migration_mode set to `MIGRATING` first. The difference here is that the previous surfaces are marked as deprecated, and the samples use the new surface.