### PR TITLE
chore: Updated dependency on google-cloud-compute-v1

### DIFF
--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -21,7 +21,7 @@ ruby_cloud_gapic_library(
     srcs = ["//google/cloud/compute/v1:compute_proto_with_info"],
     extra_protoc_parameters = [
         "ruby-cloud-gem-name=google-cloud-compute",
-        "ruby-cloud-wrapper-of=v1:2.11",
+        "ruby-cloud-wrapper-of=v1:2.15",
         "ruby-cloud-product-url=https://cloud.google.com/compute/",
         "ruby-cloud-api-id=compute.googleapis.com",
         "ruby-cloud-api-shortname=compute",


### PR DESCRIPTION
This is for the Ruby wrapper client for compute. The latest change includes a new service, and version 2.15 of the gapic is needed for that service.