### PR TITLE
feat(build_events): Add `retry_of` field to `InvocationAttemptStarted`

### DIFF
--- a/google/devtools/build/v1/build_events.proto
+++ b/google/devtools/build/v1/build_events.proto
@@ -39,6 +39,10 @@ message BuildEvent {
 
     // Arbitrary details about the invocation attempt.
     google.protobuf.Any details = 2;
+
+    // If attempt_number > 1, the invocation ID of the previous attempt if
+    // known.
+    string retry_of = 3;
   }
 
   // Notification that an invocation attempt has finished.


### PR DESCRIPTION
This will be used to inform BES clients of previous attempts linked to the current invocation (see https://github.com/bazelbuild/bazel/pull/25303).