### PR TITLE
build: deploy use of converter config in GCE BUILD rule + DIREGAPIC action

### DIFF
--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -24,6 +24,7 @@ jobs:
         git config --global --add safe.directory /__w/googleapis/googleapis
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_gen
         cp bazel-bin/google/cloud/compute/v1/compute_gen.proto google/cloud/compute/v1/compute.proto
+        cp bazel-bin/google/cloud/compute/v1/compute_gen.config.out.json google/cloud/compute/v1/compute.config.json
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_grpc_service_config_gen
         cp bazel-bin/google/cloud/compute/v1/compute_grpc_service_config_gen.json google/cloud/compute/v1/compute_grpc_service_config.json
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_gapic_gen

--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -43,6 +43,7 @@ proto_from_disco(
     name = "compute_gen",
     src = "compute.v1.json",
     enums_as_strings = True,
+    input_config_path = "compute.config.json",
     message_ignorelist = _MESSAGE_IGNORE_LIST,
     previous_proto = "compute.proto",
     service_ignorelist = _SERVICE_IGNORELIST,

--- a/google/cloud/compute/v1/compute.config.json
+++ b/google/cloud/compute/v1/compute.config.json
@@ -1,0 +1,13 @@
+{
+  "converterVersion": "UNSPECIFIED",
+  "apiVersion": "",
+  "discoveryRevision": "",
+  "inlineSchemas" : [{
+    "schema": "",
+    "locations": {
+      "ErrorSet": [
+        "schemas.ManagedInstanceLastAttempt.errors"
+      ]
+    }
+  }]
+}

--- a/google/cloud/compute/v1/compute.config.json
+++ b/google/cloud/compute/v1/compute.config.json
@@ -5,7 +5,7 @@
   "inlineSchemas" : [{
     "schema": "",
     "locations": {
-      "ErrorSet": [
+      "ManagedInstanceLastAttemptErrors": [
         "schemas.ManagedInstanceLastAttempt.errors"
       ]
     }


### PR DESCRIPTION
This will start working once the `WORKSPACE` file is updated to or past [this one](https://github.com/googleapis/disco-to-proto3-converter/commit/ebc9e9e267bfbc9a1173dd5f212a2dd03bf7b9d5); the source-of-truth of that is Google-internal and gets propagated out.