### PR TITLE
chore: make BUILD.bazel compatible with bazel 8

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,7 @@ genrule(
   name = "build_gen",
   outs = ["build_gen.sh"],
   executable = True,
-  srcs = glob(["run_build_gen.sh"]),
+  srcs = glob(["run_build_gen.sh"], allow_empty=True),
   cmd = """
     if test -z \"$(SRCS)\"; then
       cat <<EOD > $@


### PR DESCRIPTION
bazel 8 changes the default value of `allow_empty` from `True` to `False`. This PR explicitly sets `allow_empty=True` in order to be compatible and preserve the existing behavior.