### PR TITLE
build: skip DIREGAPIC PRs if only the config changed

### DIFF
--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -35,8 +35,10 @@ jobs:
         git diff-index HEAD
         echo "Diff index, filtered:"
         git diff-index HEAD | grep -v compute.config.json
-        echo Code: $?
-        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
+        echo == Code: $?
+        echo == computed api_changes: $( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
+        echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
+        echo "----"
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -36,6 +36,7 @@ jobs:
         echo "Diff index, filtered:"
         git diff-index HEAD | grep -v compute.config.json
         echo Code: $?
+        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json >& /dev/null ; } && git diff-index --shortstat HEAD)
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -30,13 +30,13 @@ jobs:
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_gapic_gen
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
         # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
-        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json >& /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
+        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
         echo "Diff index:"
         git diff-index HEAD
         echo "Diff index, filtered:"
         git diff-index HEAD | grep -v compute.config.json
         echo Code: $?
-        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json >& /dev/null ; } && git diff-index --shortstat HEAD)
+        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -31,6 +31,7 @@ jobs:
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
         # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
         echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json >& /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
+        git diff-index HEAD
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -19,6 +19,9 @@ jobs:
       run: |
         curl https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/refs/heads/master/discoveries/compute.v1.json --output google/cloud/compute/v1/compute.v1.json
         echo compute_revision=$(grep -oP '"revision":\s*"\d+"' google/cloud/compute/v1/compute.v1.json | grep -oP '\d+') >> $GITHUB_ENV
+        echo == compute_revision=$(grep -oP '"revision":\s*"\d+"' google/cloud/compute/v1/compute.v1.json | grep -oP '\d+')
+        echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
+        echo "----"
     - name: Regenerate API definitions
       run: |
         git config --global --add safe.directory /__w/googleapis/googleapis

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -48,6 +48,9 @@ jobs:
         git diff --stat
         echo === diff
         echo $( { git diff --stat | grep -v file | grep -v compute.config.json ; } )
+        echo === Status code
+        git diff --stat | grep -v file | grep -v compute.config.json ;
+        echo "-- Status code: $?"
         echo === computing
         echo $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo "HAVE changes" || echo "NO CHANGES" )        
     - name: Build GAPIC clients

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -40,10 +40,14 @@ jobs:
         # git diff-index HEAD | grep -v compute.config.json
         # echo == Code: $?
         # echo == computed api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
-        # echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
-        # echo "----"
+        echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
+        echo "----"
         echo === git diff
         git diff
+        echo === git diff --stat
+        git diff --stat
+        echo === computing
+        echo $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo "HAVE changes" || echo "NO CHANGES" )
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -29,10 +29,8 @@ jobs:
         cp bazel-bin/google/cloud/compute/v1/compute_grpc_service_config_gen.json google/cloud/compute/v1/compute_grpc_service_config.json
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_gapic_gen
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
-        # Skip any config-only changes when determining whether the API changed:
-        # - The execution timestamp recorded in the config will always differ from the previous one
-        # - Some schema hashes appear to change for no reason (internal issue 406083082)
-        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
+        # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
+        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json >& /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -33,13 +33,13 @@ jobs:
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_gapic_gen
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
         # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
-        echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
+        echo api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
         echo "Diff index:"
         git diff-index HEAD
         echo "Diff index, filtered:"
         git diff-index HEAD | grep -v compute.config.json
         echo == Code: $?
-        echo == computed api_changes: $( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
+        echo == computed api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
         echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
         echo "----"
         echo === git diff

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -33,7 +33,7 @@ jobs:
         bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1:compute_gapic_gen
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
         # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
-        echo api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
+        echo api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
         # echo "Diff index:"
         # git diff-index HEAD
         # echo "Diff index, filtered:"
@@ -49,14 +49,17 @@ jobs:
         echo === diff
         echo $( { git diff --stat | grep -v file | grep -v compute.config.json ; } )
         echo === Use status code
+        # returns NO:
         git diff --stat | grep -v file | grep -v compute.config.json && echo YES || echo NO
+        # returns NO
         echo "--- In an echo: $( { git diff --stat | grep -v file | grep -v compute.config.json  ; } && echo YES || echo NO )"
+        #returns YES !!!
         echo "--- In an echo, redirected : $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo YES || echo NO )"
-        echo === Status code
-        git diff --stat | grep -v file | grep -v compute.config.json ;
-        echo "-- Status code: $?"
+        #echo === Status code
+        #git diff --stat | grep -v file | grep -v compute.config.json ;
+        #echo "-- Status code: $?"
         echo === computing
-        echo $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo "HAVE changes" || echo "NO CHANGES" )        
+        echo $( { git diff --stat | grep -v file | grep -v compute.config.json ; } && echo "HAVE changes" || echo "NO CHANGES" )        
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -40,22 +40,8 @@ jobs:
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |
-        bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1/...
-        bazelisk build --experimental_convenience_symlinks=normal //google/cloud/compute/v1/...
+        echo "Would Build"
     - name: Create PR
-      uses: googleapis/code-suggester@v2
       if: contains(env.api_changes, 'file')
-      env:
-        ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      with:
-        command: pr
-        upstream_owner: googleapis
-        upstream_repo: googleapis
-        title: 'feat: [DIREGAPIC] Update API definitions'
-        description: 'feat: Update Compute Engine API to revision ${{ env.compute_revision }}'
-        message: 'feat: Update Compute Engine API to revision ${{ env.compute_revision }}'
-        primary: 'master'
-        branch: diregapic
-        git_dir: '.'
-        force: true
-        fork: true
+      run: |
+        echo "Would create PR"

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -42,6 +42,8 @@ jobs:
         echo == computed api_changes: $( { git diff-index HEAD | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
         echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
         echo "----"
+        echo === git diff
+        git diff
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -42,8 +42,8 @@ jobs:
         # echo == computed api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
         # echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
         # echo "----"
-        # echo === git diff
-        # git diff
+        echo === git diff
+        git diff
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -46,8 +46,10 @@ jobs:
         git diff
         echo === git diff --stat
         git diff --stat
+        echo === diff
+        echo $( { git diff --stat | grep -v file | grep -v compute.config.json ; } )
         echo === computing
-        echo $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo "HAVE changes" || echo "NO CHANGES" )
+        echo $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo "HAVE changes" || echo "NO CHANGES" )        
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -50,6 +50,8 @@ jobs:
         echo $( { git diff --stat | grep -v file | grep -v compute.config.json ; } )
         echo === Use status code
         git diff --stat | grep -v file | grep -v compute.config.json && echo YES || echo NO
+        echo "--- In an echo: $( { git diff --stat | grep -v file | grep -v compute.config.json  ; } && echo YES || echo NO )"
+        echo "--- In an echo, redirected : $( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && echo YES || echo NO )"
         echo === Status code
         git diff --stat | grep -v file | grep -v compute.config.json ;
         echo "-- Status code: $?"

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -31,7 +31,11 @@ jobs:
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
         # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
         echo api_changes=$( { git diff-index HEAD | grep -v compute.config.json >& /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
+        echo "Diff index:"
         git diff-index HEAD
+        echo "Diff index, filtered:"
+        git diff-index HEAD | grep -v compute.config.json
+        echo Code: $?
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -48,6 +48,8 @@ jobs:
         git diff --stat
         echo === diff
         echo $( { git diff --stat | grep -v file | grep -v compute.config.json ; } )
+        echo === Use status code
+        git diff --stat | grep -v file | grep -v compute.config.json && echo YES || echo NO
         echo === Status code
         git diff --stat | grep -v file | grep -v compute.config.json ;
         echo "-- Status code: $?"

--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -34,16 +34,16 @@ jobs:
         cp bazel-bin/google/cloud/compute/v1/compute_gapic_gen.yaml google/cloud/compute/v1/compute_gapic.yaml
         # DO NOT MERGE: This needs to be submitted to the Google-internal SoT
         echo api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD) >> $GITHUB_ENV
-        echo "Diff index:"
-        git diff-index HEAD
-        echo "Diff index, filtered:"
-        git diff-index HEAD | grep -v compute.config.json
-        echo == Code: $?
-        echo == computed api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
-        echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
-        echo "----"
-        echo === git diff
-        git diff
+        # echo "Diff index:"
+        # git diff-index HEAD
+        # echo "Diff index, filtered:"
+        # git diff-index HEAD | grep -v compute.config.json
+        # echo == Code: $?
+        # echo == computed api_changes=$( { git diff --stat | grep -v file | grep -v compute.config.json &> /dev/null ; } && git diff-index --shortstat HEAD)
+        # echo == github_env: $GITHUB_ENV : $(cat $GITHUB_ENV)
+        # echo "----"
+        # echo === git diff
+        # git diff
     - name: Build GAPIC clients
       if: contains(env.api_changes, 'file')
       run: |


### PR DESCRIPTION
This is a temporary workaround for internal issue b/406083082, where the schema hashes sometimes change without the source schema having changed. We want to avoid spurious PRs.