### PR TITLE
feat(http): add support for mapping headers to request fields

### DIFF
--- a/google/api/http.proto
+++ b/google/api/http.proto
@@ -45,17 +45,18 @@ message Http {
 // gRPC Transcoding is a feature for mapping between a gRPC method and one or
 // more HTTP REST endpoints. It allows developers to build a single API service
 // that supports both gRPC APIs and REST APIs. Many systems, including [Google
-// APIs](https://github.com/googleapis/googleapis),
-// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
-// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
-// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
-// and use it for large scale production services.
+// APIs](https://github.com/googleapis/googleapis), [Cloud
+// Endpoints](https://cloud.google.com/endpoints), [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway), and
+// [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature and
+// use it for large scale production services.
 //
 // `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
 // how different portions of the gRPC request message are mapped to the URL
-// path, URL query parameters, and HTTP request body. It also controls how the
-// gRPC response message is mapped to the HTTP response body. `HttpRule` is
-// typically specified as an `google.api.http` annotation on the gRPC method.
+// path, URL query parameters, HTTP headers, and HTTP request body. It also
+// controls how the gRPC response message is mapped to the HTTP response body.
+// `HttpRule` is typically specified as an `google.api.http` annotation on the
+// gRPC method.
 //
 // Each mapping specifies a URL path template and an HTTP method. The path
 // template may refer to one or more fields in the gRPC request message, as long
@@ -85,8 +86,8 @@ message Http {
 // - gRPC: `GetMessage(name: "messages/123456")`
 //
 // Any fields in the request message which are not bound by the path template
-// automatically become HTTP query parameters if there is no HTTP request body.
-// For example:
+// nor specified as values in `request_headers` automatically become HTTP query
+// parameters if there is no HTTP request body. For example:
 //
 //     service Messaging {
 //       rpc GetMessage(GetMessageRequest) returns (Message) {
@@ -112,14 +113,13 @@ message Http {
 //
 // Note that fields which are mapped to URL query parameters must have a
 // primitive type or a repeated primitive type or a non-repeated message type.
-// In the case of a repeated type, the parameter can be repeated in the URL
-// as `...?param=A&param=B`. In the case of a message type, each field of the
+// In the case of a repeated type, the parameter can be repeated in the URL as
+// `...?param=A&param=B`. In the case of a message type, each field of the
 // message is mapped to a separate parameter, such as
 // `...?foo.a=A&foo.b=B&foo.c=C`.
 //
-// For HTTP methods that allow a request body, the `body` field
-// specifies the mapping. Consider a REST update method on the
-// message resource collection:
+// For HTTP methods that allow a request body, the `body` field specifies the
+// mapping. Consider a REST update method on the message resource collection:
 //
 //     service Messaging {
 //       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
@@ -134,17 +134,15 @@ message Http {
 //       Message message = 2;   // mapped to the body
 //     }
 //
-// The following HTTP JSON to RPC mapping is enabled, where the
-// representation of the JSON in the request body is determined by
-// protos JSON encoding:
+// The following HTTP JSON to RPC mapping is enabled, where the representation
+// of the JSON in the request body is determined by protos JSON encoding:
 //
 // - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
 // - gRPC: `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
 //
-// The special name `*` can be used in the body mapping to define that
-// every field not bound by the path template should be mapped to the
-// request body.  This enables the following alternative definition of
-// the update method:
+// The special name `*` can be used in the body mapping to define that every
+// field not bound by the path template should be mapped to the request body.
+// This enables the following alternative definition of the update method:
 //
 //     service Messaging {
 //       rpc UpdateMessage(Message) returns (Message) {
@@ -165,14 +163,14 @@ message Http {
 // - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
 // - gRPC: `UpdateMessage(message_id: "123456" text: "Hi!")`
 //
-// Note that when using `*` in the body mapping, it is not possible to
-// have HTTP parameters, as all fields not bound by the path end in
-// the body. This makes this option more rarely used in practice when
-// defining REST APIs. The common usage of `*` is in custom methods
-// which don't use the URL at all for transferring data.
+// Note that when using `*` in the body mapping, it is not possible to have HTTP
+// parameters, as all fields not bound by the path end in the body. This makes
+// this option more rarely used in practice when defining REST APIs. The common
+// usage of `*` is in custom methods which don't use the URL at all for
+// transferring data.
 //
-// It is possible to define multiple HTTP methods for one RPC by using
-// the `additional_bindings` option. Example:
+// It is possible to define multiple HTTP methods for one RPC by using the
+// `additional_bindings` option. Example:
 //
 //     service Messaging {
 //       rpc GetMessage(GetMessageRequest) returns (Message) {
@@ -203,18 +201,15 @@ message Http {
 //    message) are classified into three categories:
 //    - Fields referred by the path template. They are passed via the URL path.
 //    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
-//    are passed via the HTTP
-//      request body.
+//    are passed via the HTTP request body.
 //    - All other fields are passed via the URL query parameters, and the
 //      parameter name is the field path in the request message. A repeated
 //      field can be represented as multiple query parameters under the same
 //      name.
 //  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
-//  query parameter, all fields
-//     are passed via URL path and HTTP request body.
+//  query parameter, all fields are passed via URL path and HTTP request body.
 //  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
-//  request body, all
-//     fields are passed via URL path and URL query parameters.
+//  request body, all fields are passed via URL path and URL query parameters.
 //
 // Path template syntax
 //
@@ -231,8 +226,8 @@ message Http {
 //
 // The syntax `Variable` matches part of the URL path as specified by its
 // template. A variable template must not contain other variables. If a variable
-// matches a single path segment, its template may be omitted, e.g. `{var}`
-// is equivalent to `{var=*}`.
+// matches a single path segment, its template may be omitted, e.g. `{var}` is
+// equivalent to `{var=*}`.
 //
 // The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
 // contains any reserved character, such characters should be percent-encoded
@@ -240,33 +235,31 @@ message Http {
 //
 // If a variable contains exactly one path segment, such as `"{var}"` or
 // `"{var=*}"`, when such a variable is expanded into a URL path on the client
-// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
-// server side does the reverse decoding. Such variables show up in the
-// [Discovery
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The server
+// side does the reverse decoding. Such variables show up in the [Discovery
 // Document](https://developers.google.com/discovery/v1/reference/apis) as
 // `{var}`.
 //
-// If a variable contains multiple path segments, such as `"{var=foo/*}"`
-// or `"{var=**}"`, when such a variable is expanded into a URL path on the
-// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
-// The server side does the reverse decoding, except "%2F" and "%2f" are left
-// unchanged. Such variables show up in the
-// [Discovery
+// If a variable contains multiple path segments, such as `"{var=foo/*}"` or
+// `"{var=**}"`, when such a variable is expanded into a URL path on the client
+// side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. The
+// server side does the reverse decoding, except "%2F" and "%2f" are left
+// unchanged. Such variables show up in the [Discovery
 // Document](https://developers.google.com/discovery/v1/reference/apis) as
 // `{+var}`.
 //
 // Using gRPC API Service Configuration
 //
 // gRPC API Service Configuration (service config) is a configuration language
-// for configuring a gRPC service to become a user-facing product. The
-// service config is simply the YAML representation of the `google.api.Service`
-// proto message.
+// for configuring a gRPC service to become a user-facing product. The service
+// config is simply the YAML representation of the `google.api.Service` proto
+// message.
 //
 // As an alternative to annotating your proto file, you can configure gRPC
 // transcoding in your service config YAML files. You do this by specifying a
 // `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
-// effect as the proto annotation. This can be particularly useful if you
-// have a proto that is reused in multiple services. Note that any transcoding
+// effect as the proto annotation. This can be particularly useful if you have a
+// proto that is reused in multiple services. Note that any transcoding
 // specified in the service config will override any matching transcoding
 // configuration in the proto.
 //
@@ -279,17 +272,17 @@ message Http {
 //
 // Special notes
 //
-// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
-// proto to JSON conversion must follow the [proto3
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the proto
+// to JSON conversion must follow the [proto3
 // specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
 //
-// While the single segment variable follows the semantics of
-// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+// While the single segment variable follows the semantics of [RFC
+// 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
 // Expansion, the multi segment variable **does not** follow RFC 6570 Section
-// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
-// does not expand special characters like `?` and `#`, which would lead
-// to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
-// for multi segment variables.
+// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion does not
+// expand special characters like `?` and `#`, which would lead to invalid URLs.
+// As the result, gRPC Transcoding uses a custom encoding for multi segment
+// variables.
 //
 // The path variables **must not** refer to any repeated or mapped field,
 // because client libraries are not capable of handling such variable expansion.
@@ -346,6 +339,18 @@ message HttpRule {
   // message type.
   string body = 7;
 
+  // The name of fields whose values are mapped to HTTP headers in a request. If
+  // a header has a case-insensitive match to a key in this map, the field in
+  // the request that matches the value will have it's value set with the value
+  // in the header.
+  //
+  // If a field is specified in this map, it will not be mapped to a query
+  // parameter.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  map<string,string> request_headers = 13;
+
   // Optional. The name of the response field whose value is mapped to the HTTP
   // response body. When omitted, the entire response message will be used
   // as the HTTP response body.
@@ -353,6 +358,15 @@ message HttpRule {
   // NOTE: The referred field must be present at the top-level of the response
   // message type.
   string response_body = 12;
+
+  // The name of fields whose values are mapped to HTTP headers in a response.
+  // If a field is in the response that matches a value in this map, an HTTP
+  // response header with the name of the key in the map will be populated
+  // with that value.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  map<string,string> response_headers = 14;
 
   // Additional HTTP bindings for the selector. Nested bindings must
   // not contain an `additional_bindings` field themselves (that is,


### PR DESCRIPTION
Hello! This is primarily a way to start a conversation, but I wanted to illustrate a somewhat clear proposal as well.

This proposes a method to map HTTP headers to requests and  responses in a protobuf request.

This is useful for implementing IETF RFCs (such as 9110's if-match header) in HTTP+JSON apis that 
are exposed in gRPC-JSON transcoding.

This was also brought up in a GitHub discussion: (see https://github.com/googleapis/googleapis/discussions/749)