### PR TITLE
fix!: Remove schemas.MachineType.scratchDisks.scratchDisk from config

### DIFF
--- a/google/cloud/compute/v1/compute.config.json
+++ b/google/cloud/compute/v1/compute.config.json
@@ -5473,14 +5473,6 @@
       }
     },
     {
-      "schema": "577aeaab",
-      "locations": {
-        "ScratchDisks": [
-          "schemas.MachineType.scratchDisks.scratchDisks"
-        ]
-      }
-    },
-    {
       "schema": "7b1994fc",
       "locations": {
         "SendDiagnosticInterruptInstanceRequest": [


### PR DESCRIPTION
The field and type have already been through a deprecation process.  This is an intended breaking change. Googlers: see [cl/751378213](http://cl/751378213)