### PR TITLE
build: Remove ScratchDisks to disable breaking change warning

### DIFF
--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -20100,9 +20100,6 @@ message MachineType {
   // [Output Only] Name of the resource.
   optional string name = 3373707;
 
-  // [Output Only] A list of extended scratch disks assigned to the instance.
-  repeated ScratchDisks scratch_disks = 480778481;
-
   // [Output Only] Server-defined URL for the resource.
   optional string self_link = 456214797;
 
@@ -29269,13 +29266,6 @@ message SchedulingNodeAffinity {
 message SchedulingOnInstanceStopAction {
   // If true, the contents of any attached Local SSD disks will be discarded else, the Local SSD data will be preserved when the instance is stopped at the end of the run duration/termination time.
   optional bool discard_local_ssd = 319517903;
-
-}
-
-//
-message ScratchDisks {
-  // Size of the scratch disk, defined in GB.
-  optional int32 disk_gb = 60990141;
 
 }
 


### PR DESCRIPTION
The field and type have already been through a deprecation process. This is an intended breaking change. See PR #1027

Googlers: see cl/751378213