### PR TITLE
build(python): add service_yaml and rest_numeric_enums configurations for google/cloud/compute builds

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -238,6 +238,8 @@ load(
 
 py_gapic_library(
     name = "compute_py_gapic",
+    rest_numeric_enums = False,
+    service_yaml = "compute_v1.yaml",
     srcs = [
         ":compute_proto",
     ],

--- a/google/cloud/compute/v1beta/BUILD.bazel
+++ b/google/cloud/compute/v1beta/BUILD.bazel
@@ -238,6 +238,8 @@ load(
 
 py_gapic_library(
     name = "compute_py_gapic",
+    rest_numeric_enums = False,
+    service_yaml = "compute_v1beta.yaml",
     srcs = [
         ":compute_proto",
     ],


### PR DESCRIPTION
This PR adds the following configurations for google/cloud/compute Python GAPIC builds

- rest_numeric_enums
- service_yaml


Setting `rest_numeric_enums` to `False` is a no-op because `False` is the default value. This was only added for completeness.

https://github.com/googleapis/gapic-generator-python/blob/01aed595d5deffd996410acf6b9f7eca737d027d/rules_python_gapic/py_gapic.bzl#L46


`rest_numeric_enums` could be set to `True` in the future however it's not clear what the downstream impact will be. I'd rather not make that change in this PR.

FWIW, the following command works
```
curl -X GET -H "Authorization: Bearer $(gcloud auth print-access-token)" "https://compute.googleapis.com/compute/v1/projects/<REDACTED PROJECT ID>/aggregated/instances?alt=json%3Benum-encoding%3Dint"
```