### PR TITLE
Add iceberg mapping for python sdk pb

### DIFF
--- a/google/cloud/dataproc/v1/shared.proto
+++ b/google/cloud/dataproc/v1/shared.proto
@@ -573,6 +573,9 @@ enum Component {
   // Hudi.
   HUDI = 18;
 
+  // Iceberg.
+  ICEBERG = 42;
+
   // The Jupyter Notebook.
   JUPYTER = 1;
 


### PR DESCRIPTION
 ```python 
from google.cloud import dataproc_v1

 config = {
            "project_id": "...",
            "cluster_name":"...",
            "config": { "software_config": {
                    "optional_components": ["ICEBERG"],  
                }
}

dataproc_v1.ClusterControllerClient().create_cluster(
            request={
                "project_id": self.project_id,
                "region": self.region,
                "cluster": cluster_config
            }
  ```
  
  was giving an error like this
  
`File "/home/linuxbrew/.linuxbrew/opt/python@3.13/lib/python3.13/enum.py", line 790, in __getitem__
    return cls._member_map_[name]
    ^^^^^^
KeyError: 'ICEBERG'
`

I don't really know what the process is here but the contributing.md didn't give me much 🙂 

Issue in the [google-cloud-python repo](https://github.com/googleapis/google-cloud-python/issues/13958)
