### PR TITLE
build: change runner image so as to access git executable

### DIFF
--- a/.github/workflows/diregapic.yaml
+++ b/.github/workflows/diregapic.yaml
@@ -9,7 +9,7 @@ jobs:
   regenerate-compute:
     if: github.repository == 'googleapis/googleapis'
     runs-on: ubuntu-latest
-    container: gcr.io/gapic-images/googleapis:prod
+    container: gcr.io/gapic-images/googleapis:20250505
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The current instance of the runner labeled `prod` no longer provides access to the `git` executable, thus breaking the DIREGAPIC action.