### PR TITLE
fix: Add missing PlaybookType to playbook proto

### DIFF
--- a/google/cloud/dialogflow/cx/v3beta1/playbook.proto
+++ b/google/cloud/dialogflow/cx/v3beta1/playbook.proto
@@ -319,6 +319,9 @@ message Playbook {
   // Optional. A list of registered handlers to execute based on the specified
   // triggers.
   repeated Handler handlers = 16 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The playbook type to use.
+  PlaybookType playbook_type = 19 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // The request message for
@@ -336,6 +339,15 @@ message CreatePlaybookVersionRequest {
 
   // Required. The playbook version to create.
   PlaybookVersion playbook_version = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Playbook type determines whether a playbook can use session data and orchestrate other
+// playbooks (Routine type) or returns immediately to the Routine playbook that invoked it
+// (Task type). An unspecified playbook type defaults to the Task type.
+enum PlaybookType {
+  PLAYBOOK_TYPE_UNSPECIFIED = 0;
+  TASK = 1;
+  ROUTINE = 3;
 }
 
 // Playbook version is a snapshot of the playbook at certain timestamp.


### PR DESCRIPTION
Add missing [PlaybookType](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3beta1/projects.locations.agents.playbooks#playbooktype) to the playbook proto so that users can CREATE and PATCH routine playbooks. Currently, Google's API SDKs do not expose this field, limiting users to operations on task playbooks only.

Please verify that the enum values are correct, as it was reverse engineered.