### PR TITLE
chore: remove stale comment

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -332,9 +332,6 @@ nodejs_gapic_assembly_pkg(
 ###############################################################################
 # Ruby
 ###############################################################################
-# TODO(b/337043087#comment3): Re-enable this Ruby section once Ruby
-# GAPIC generation can deal with current GCE special cases.
-
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "ruby_cloud_gapic_library",


### PR DESCRIPTION
Verified that the DIREGAPIC action runs successfully with the Ruby rules enabled (done in #1067), so we can delete the stale comment referencing the issue.