### PR TITLE
chore(php): set Compute migration_mode to NEW_SURFACE_ONLY

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -287,7 +287,7 @@ php_gapic_library(
     grpc_service_config = "compute_grpc_service_config.json",
     service_yaml = "compute_v1.yaml",
     transport = "rest",
-    migration_mode = "MIGRATING",
+    migration_mode = "NEW_SURFACE_ONLY",
     deps = [
         ":compute_php_proto",
     ],


### PR DESCRIPTION
Completing the migration of the Compute library to the new PHP Surface. See https://github.com/googleapis/googleapis/pull/967

The results are generated here: https://github.com/googleapis/google-cloud-php/pull/8590