### PR TITLE
chore: update published package name

### DIFF
--- a/google/cloud/compute/v1small/BUILD.bazel
+++ b/google/cloud/compute/v1small/BUILD.bazel
@@ -157,7 +157,7 @@ load(
 # Node.js Compute Small (for testing and prototyping purposes)
 nodejs_gapic_library(
     name = "compute_small_nodejs_gapic",
-    package_name = "@google-cloud/compute-small",
+    package_name = "@google-cloud/compute",
     src = ":compute_small_proto_with_info",
     extra_protoc_parameters = ["metadata"],
     diregapic = True,


### PR DESCRIPTION
Nodejs' compute version doesn't publish compute-small, we only publish @google-cloud/compute