### PR TITLE
fix: Add missing load statements for py_test

### DIFF
--- a/google/cloud/asset/v1p7beta1/BUILD.bazel
+++ b/google/cloud/asset/v1p7beta1/BUILD.bazel
@@ -33,6 +33,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/cloud/bigquery/connection/v1beta1/BUILD.bazel
+++ b/google/cloud/bigquery/connection/v1beta1/BUILD.bazel
@@ -152,6 +152,7 @@ load(
     "@com_google_googleapis_imports//:imports.bzl",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
 )
 
 py_gapic_library(

--- a/google/cloud/bigquery/storage/v1/BUILD.bazel
+++ b/google/cloud/bigquery/storage/v1/BUILD.bazel
@@ -26,6 +26,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/cloud/bigquery/storage/v1beta2/BUILD.bazel
+++ b/google/cloud/bigquery/storage/v1beta2/BUILD.bazel
@@ -153,6 +153,7 @@ load(
     "@com_google_googleapis_imports//:imports.bzl",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
 )
 
 py_gapic_library(

--- a/google/cloud/recommendationengine/v1beta1/BUILD.bazel
+++ b/google/cloud/recommendationengine/v1beta1/BUILD.bazel
@@ -26,6 +26,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/devtools/build/v1/BUILD.bazel
+++ b/google/devtools/build/v1/BUILD.bazel
@@ -37,6 +37,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/devtools/remoteworkers/v1test2/BUILD.bazel
+++ b/google/devtools/remoteworkers/v1test2/BUILD.bazel
@@ -31,6 +31,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/home/graph/v1/BUILD.bazel
+++ b/google/home/graph/v1/BUILD.bazel
@@ -26,6 +26,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/maps/fleetengine/delivery/v1/BUILD.bazel
+++ b/google/maps/fleetengine/delivery/v1/BUILD.bazel
@@ -21,6 +21,7 @@ load(
     "py_gapic_assembly_pkg",
     "py_gapic_library",
     "py_import",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/maps/fleetengine/v1/BUILD.bazel
+++ b/google/maps/fleetengine/v1/BUILD.bazel
@@ -21,6 +21,7 @@ load(
     "py_gapic_assembly_pkg",
     "py_gapic_library",
     "py_import",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",

--- a/google/shopping/merchant/notifications/v1beta/BUILD.bazel
+++ b/google/shopping/merchant/notifications/v1beta/BUILD.bazel
@@ -165,6 +165,7 @@ load(
     "py_gapic_assembly_pkg",
     "py_gapic_library",
     "py_import",
+    "py_test",
 )
 
 py_import(

--- a/google/shopping/merchant/reports/v1alpha/BUILD.bazel
+++ b/google/shopping/merchant/reports/v1alpha/BUILD.bazel
@@ -166,6 +166,7 @@ load(
     "py_gapic_assembly_pkg",
     "py_gapic_library",
     "py_import",
+    "py_test",
 )
 
 py_import(

--- a/google/shopping/merchant/reports/v1beta/BUILD.bazel
+++ b/google/shopping/merchant/reports/v1beta/BUILD.bazel
@@ -166,6 +166,7 @@ load(
     "py_gapic_assembly_pkg",
     "py_gapic_library",
     "py_import",
+    "py_test",
 )
 
 py_import(

--- a/google/storage/v2/BUILD.bazel
+++ b/google/storage/v2/BUILD.bazel
@@ -33,6 +33,7 @@ load(
     "proto_library_with_info",
     "py_gapic_assembly_pkg",
     "py_gapic_library",
+    "py_test",
     "ruby_cloud_gapic_library",
     "ruby_gapic_assembly_pkg",
     "ruby_grpc_library",


### PR DESCRIPTION
Starting with Bazel 9 it's an error to rely on the builtin ones.

As a follow-up it'd be desirable to also change the `native.py_test` used in the repository rules to the `rules_python` variant.