### PR TITLE
chore(preview): fix compute preview gen

### DIFF
--- a/preview/google/cloud/compute/v1/BUILD.bazel
+++ b/preview/google/cloud/compute/v1/BUILD.bazel
@@ -38,7 +38,7 @@ _SERVICE_IGNORELIST = [
 ]
 
 proto_from_disco(
-    name = "compute_preview_gen",
+    name = "compute_gen",
     src = "compute.v1.json",
     enums_as_strings = True,
     input_config_path = "compute.config.json",


### PR DESCRIPTION
Rename the `proto_from_disco` target for preview compute to align with the stable directory's target name. Also fixes the github action expecting that target name and output file naming format.